### PR TITLE
RDKBDEV-3268 : Prevent Memory Leak in CcspLMLite Event Handler for Bridge Mode

### DIFF
--- a/source/lm/lm_main.c
+++ b/source/lm/lm_main.c
@@ -2281,6 +2281,10 @@ static void *Event_HandlerThread(void *threadid)
         /* CID 339816 String not null terminated */
         EventMsg.Msg[MAX_SIZE_EVT-1] = '\0';
         do_dhcpsync = FALSE;
+        if(Hosts_stop_scan())
+        {
+            continue;
+        }
 
         if(EventMsg.MsgType == MSG_TYPE_ETH)
         {


### PR DESCRIPTION
Reason for change:
A memory leak was observed in the /usr/bin/CcspLMLite process when the DUT was running in bridge mode for an extended period (4 days) with continuous LAN traffic. The available memory (MemAvailable) declined by 57MB, and the RSS for CcspLMLite kept increasing, indicating the process was not releasing memory as expected.

Risk:
Added a check for Hosts_stop_scan() in the Event_HandlerThread function in lm_main.c. If host scanning should be stopped, the thread skips further event processing by using continue, preventing unnecessary memory allocation and resource usage in bridge mode.

Test Procedure:
1. Flash the image with the patch and boot up the DUT in bridge mode.
2. Connect a LAN client and start traffic of 40Mbps upstream and 40Mbps downstream.
3. Keep the DUT running for several days (Here we kept for 4 days).
4. Monitor memory usage using top and check MemAvailable and RSS for /usr/bin/CcspLMLite.
5. Confirm that memory usage remains stable and does not show a continuous increase.
6. Verify that there is no regression in host management or event handling in other modes.

Signed Off By:
Ananya Singh (ananya.singh@vantiva.com)