### PR TITLE
RDKBDEV-3353: RDKCOM-5506 IPQ: Increase host object size for IPQ devices

### DIFF
--- a/source/lm/lm_main.c
+++ b/source/lm/lm_main.c
@@ -109,7 +109,11 @@
 #define DNS_LEASE "/nvram/dnsmasq.leases"
 #define DEBUG_INI_NAME  "/etc/debug.ini"
 #define HOST_ENTRY_LIMIT 175
+#if defined (_COSA_QCA_ARM_)
+#define HOST_OBJECT_SIZE       512
+#else
 #define HOST_OBJECT_SIZE	200
+#endif
 #define ARP_IPv6 0
 #define DIBBLER_IPv6 1
 


### PR DESCRIPTION
IPQ: Increase host object size for IPQ devices

IPQ platforms support a higher number of clients compared. The existing host object size was insufficient to handle this increased client load. This change increases the host object size to ensure proper handling and avoid resource limitations.

Reason:
- IPQ supports more clients, requiring larger host object allocation.