### PR TITLE
Fix PW.BAD_MACRO_REDEF in device_presence_detection.c

### DIFF
--- a/source/lm/device_presence_detection.c
+++ b/source/lm/device_presence_detection.c
@@ -16,8 +16,10 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-
+    
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 #include <unistd.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
## Automated Fix for PW.BAD_MACRO_REDEF

**File:** `/source/lm/device_presence_detection.c`
**Line:** 20

### Defect Details
Parse warning

### Fix Applied
This automated fix addresses the PW.BAD_MACRO_REDEF defect by:
Accept. The patch correctly and minimally fixes the macro redefinition (PW.BAD_MACRO_REDEF) by guarding the _GNU_SOURCE definition with #ifndef/#endif. It preserves header ordering and program behavior, introduces no new defects, and is not over-engineered.

### Validation
- ✅ LLM review validation passed
- ✅ Syntax validation passed (if applicable)
