### PR TITLE
Fix PW.BAD_MACRO_REDEF in lm_main.c

### DIFF
--- a/source/lm/lm_main.c
+++ b/source/lm/lm_main.c
@@ -65,7 +65,9 @@
         09/16/2011    initial revision.
 
 **************************************************************************/
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 #include <time.h>
 #include <sys/sysinfo.h>
 #include <string.h>


### PR DESCRIPTION
## Automated Fix for PW.BAD_MACRO_REDEF

**File:** `/source/lm/lm_main.c`
**Line:** 68

### Defect Details
Parse warning

### Fix Applied
This automated fix addresses the PW.BAD_MACRO_REDEF defect by:
The patch correctly fixes the macro redefinition warning by adding a simple #ifndef guard around the _GNU_SOURCE definition. The change is minimal, idiomatic, and introduces no new defects or logic changes.

### Validation
- ✅ LLM review validation passed
- ✅ Syntax validation passed (if applicable)
