### PR TITLE
Fix PW.BAD_MACRO_REDEF in lm_wrapper.c

### DIFF
--- a/source/lm/lm_wrapper.c
+++ b/source/lm/lm_wrapper.c
@@ -32,7 +32,9 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 **********************************************************************/
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <sys/ioctl.h>


### PR DESCRIPTION
## Automated Fix for PW.BAD_MACRO_REDEF

**File:** `/source/lm/lm_wrapper.c`
**Line:** 35

### Defect Details
Parse warning

### Fix Applied
This automated fix addresses the PW.BAD_MACRO_REDEF defect by:
Patch correctly and minimally fixes the PW.BAD_MACRO_REDEF issue by guarding the _GNU_SOURCE definition with an #ifndef. The change is small, safe, and preserves existing behavior without introducing new defects.

### Validation
- ✅ LLM review validation passed
- ✅ Syntax validation passed (if applicable)
