### PR TITLE
Fix TOCTOU in lm_main.c

### DIFF
--- a/source/lm/lm_main.c
+++ b/source/lm/lm_main.c
@@ -809,19 +809,19 @@ static void LM_SET_ACTIVE_STATE_TIME_(int line, LmObjectHost *pHost,BOOL state){
 			{
 				if(pHost->bNotify == FALSE)
 				{
-				   if(access("/tmp/.conn_cli_flag", F_OK) != 0)
 				   {
-					/* CID :257716 Resource leak */
-					int fd;
-					/* CID 257720 Time of check time of use */
-					if ((fd = open("/tmp/.conn_cli_flag", O_CREAT | O_EXCL | O_WRONLY, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH | O_CLOEXEC)) >= 0)
+				/* CID :257716 Resource leak, CID 257720 Time of check time of use */
+				int fd = open("/tmp/.conn_cli_flag", O_CREAT | O_EXCL | O_WRONLY, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH | O_CLOEXEC);
+				if (fd >= 0)
                                         {
                                             close(fd);
                                         }
-					get_uptime(&uptime);
-                  			CcspTraceWarning(("Client_Connect_complete:%d\n",uptime));	
-					OnboardLog("Client_Connect_complete:%d\n",uptime);
-					t2_event_d("btime_clientconn_split", uptime);
+				if (fd >= 0) {
+				get_uptime(&uptime);
+                  			CcspTraceWarning(("Client_Connect_complete:%d\n",uptime));
+				OnboardLog("Client_Connect_complete:%d\n",uptime);
+				t2_event_d("btime_clientconn_split", uptime);
+				}
 				   }
 					CcspTraceWarning(("RDKB_CONNECTED_CLIENTS: Client type is %s, MacAddress is %s and HostName is %s Connected  \n",interface,pHost->pStringParaValue[LM_HOST_PhysAddressId],pHost->pStringParaValue[LM_HOST_HostNameId]));
 					lmHosts.lastActivity++;


### PR DESCRIPTION
## Automated Fix for TOCTOU

**File:** `/source/lm/lm_main.c`
**Line:** 812

### Defect Details
Time of check time of use

### Fix Applied
This automated fix addresses the TOCTOU defect by:
The fix correctly addresses the TOCTOU defect (CID 257720) by eliminating the access() check and relying solely on open() with O_CREAT|O_EXCL for atomic file creation. The logging/telemetry calls are properly gated on the open() return value, preserving the original intent of only logging when the flag file is first created. The resource leak (CID 257716) is also properly handled with close(fd) guarded by fd >= 0. No new defects are introduced.

### Validation
- ✅ LLM review validation passed
- ✅ Syntax validation passed (if applicable)
