### PR TITLE
RDKB-60151: DscpCountPerInterval tr181 returns incorrect value

### DIFF
--- a/source/lm/cosa_wantraffic_utils.c
+++ b/source/lm/cosa_wantraffic_utils.c
@@ -890,9 +890,11 @@ pstDSCPInfo_t InsertClient(pstDSCPInfo_t DscpTree, pDSCP_list_t CliList)
                             //New Client addition
                             if (j == DscpTree->NumClients)
                             {
-                                memcpy(DscpTree->ClientList[j].Mac,
-                                       CliList->DSCP_Element[DscpTree->Dscp].Client[i].mac,
-                                       sizeof(CliList->DSCP_Element[DscpTree->Dscp].Client[i].mac));
+                                memcpy_s(DscpTree->ClientList[j].Mac,
+                                         sizeof(DscpTree->ClientList[j].Mac),
+                                         CliList->DSCP_Element[DscpTree->Dscp].Client[i].mac,
+                                         sizeof(DscpTree->ClientList[j].Mac) - 1);
+                                DscpTree->ClientList[j].Mac[sizeof(DscpTree->ClientList[j].Mac) - 1] = '\0';
                                 DscpTree->ClientList[j].RxBytes = 0;
                                 DscpTree->ClientList[j].TxBytes = 0;
                                 DscpTree->ClientList[j].RxBytesTot =

--- a/source/lm/cosa_wantraffic_utils.c
+++ b/source/lm/cosa_wantraffic_utils.c
@@ -893,10 +893,8 @@ pstDSCPInfo_t InsertClient(pstDSCPInfo_t DscpTree, pDSCP_list_t CliList)
                                 memcpy(DscpTree->ClientList[j].Mac,
                                        CliList->DSCP_Element[DscpTree->Dscp].Client[i].mac,
                                        sizeof(CliList->DSCP_Element[DscpTree->Dscp].Client[i].mac));
-                                DscpTree->ClientList[j].RxBytes =
-                                          CliList->DSCP_Element[DscpTree->Dscp].Client[i].rxBytes;
-                                DscpTree->ClientList[j].TxBytes =
-                                          CliList->DSCP_Element[DscpTree->Dscp].Client[i].txBytes;
+                                DscpTree->ClientList[j].RxBytes = 0;
+                                DscpTree->ClientList[j].TxBytes = 0;
                                 DscpTree->ClientList[j].RxBytesTot =
                                           CliList->DSCP_Element[DscpTree->Dscp].Client[i].rxBytes;
                                 DscpTree->ClientList[j].TxBytesTot =


### PR DESCRIPTION
Reason for change: Whenever the DscpCountEnable is disabled and enabled, TX and RX takes the DscpCountTotal value. So, for the new client entries, I have made changes to assign the TX and RX to 0. After this the issue is not seen.

Test Procedure: Please refer the ticket

Risks: None

Priority: P1

Change-Id: I476e1dd0b27fff085444b79cf5ede468648f903e
Signed-off-by: umasankar.srinivasan@sky.uk