### PR TITLE
RDKB-64358 : NetworkDeviceStatus report support for MLO in LMLite

### DIFF
--- a/config/NetworkDevicesStatusMLO.avsc
+++ b/config/NetworkDevicesStatusMLO.avsc
@@ -1,0 +1,234 @@
+{
+  "namespace": "com.comcast.kestrel.odp.event",
+  "name": "NetworkDevicesStatus",
+  "type": "record",
+  "doc": "Contains the status and basic details for each connected device in the CPE host table (Ethernet/Moca/WiFi). Each report contains device status and L2 counters",
+  "fields": [
+    {
+      "name": "header",
+      "type": {
+        "namespace": "com.comcast.kestrel",
+        "name": "CoreHeader",
+        "type": "record",
+        "doc": "Common information related to the event which MUST be included in any kestrel event. It allows some common processing at the system level, and some consistency for processing events.",
+        "fields": [
+          {
+            "name": "timestamp",
+            "type": [
+              "null",
+              {
+                "logicalType": "timestamp-millis",
+                "type": "long"
+              }
+            ],
+            "doc": "The UTC time stamp in milliseconds since Unix epoch (January 1, 1970 midnight) when the event is generated.",
+            "default": null
+          },
+          {
+            "name": "uuid",
+            "type": [
+              "null",
+              {
+                "name": "UUID",
+                "namespace": "com.comcast.kestrel.datatype",
+                "size": 16,
+                "type": "fixed"
+              }
+            ],
+            "doc": "Unique identifier for the event used for event de-duplication and tracing.",
+            "default": null
+          },
+          {
+            "name": "source",
+            "type": [
+              "null",
+              "string"
+            ],
+            "doc": "Source of this report - generally the application or process generating the event",
+            "default": null
+          }
+        ]
+      }
+    },
+    {
+      "name": "cpe_id",
+      "type": {
+        "namespace": "com.comcast.kestrel.odp",
+        "name": "CPEIdentifier",
+        "type": "record",
+        "doc": "Unique identifying fields for a CPE device. All fields are optional, but at least one field should be populated with a non null value",
+        "fields": [
+          {
+            "name": "mac_address",
+            "type": [
+              "null",
+              {
+                "name": "MacAddress",
+                "namespace": "com.comcast.kestrel.datatype",
+                "size": 6,
+                "type": "fixed"
+              }
+            ],
+            "doc": "Canonical (Identifying) MAC address for the gateway. (Eg, may be CM Mac for cable modems)",
+            "default": null
+          },
+          {
+            "name": "cpe_type",
+            "type": [
+              "null",
+              "string"
+            ],
+            "doc": "Contains the cpe type e.g. Extender or Gateway",
+            "default": null
+          },
+          {
+            "name": "cpe_parent",
+            "type": [
+              "null",
+              "com.comcast.kestrel.odp.CPEIdentifier"
+            ],
+            "doc": "If this device is a child device (it is managed by another CPE device), this field identifies the parent device. Canonical identifier for the CPE. (Eg, may be CM Mac for cable modems)",
+            "default": null
+          }
+        ]
+      }
+    },
+    {
+      "name": "host_table_version",
+      "type": [
+        "null",
+        "long"
+      ],
+      "doc": "Version Number after the latest change (add/delete/hostname update) was done to the Device.Hosts. table",
+      "default": null
+    },
+    {
+      "name": "data",
+      "type": {
+        "items": {
+          "namespace": "com.comcast.kestrel.odp",
+          "name": "NetworkDeviceStatus",
+          "type": "record",
+          "doc": "Contains gateway network and L3 data for a network related to a specific connected device at a point in time",
+          "fields": [
+            {
+              "name": "device_id",
+              "type": {
+                "namespace": "com.comcast.kestrel.odp",
+                "name": "ConnectedDeviceIdentifier",
+                "type": "record",
+                "doc": "Identifies a connected device",
+                "fields": [
+                  {
+                    "name": "mac_address",
+                    "type": [
+                      "null",
+                      "com.comcast.kestrel.datatype.MacAddress"
+                    ],
+                    "doc": "MAC address of the conected device the report is related to",
+                    "default": null
+                  },
+                  {
+                    "name": "device_type",
+                    "type": [
+                      "null",
+                      "string"
+                    ],
+                    "doc": "Device Type connected to the Gateway [TR-181: Device.Hosts.Host.{i}.X_RDKCENTRAL_COM-DeviceType]",
+                    "default": null
+                  }
+                ]
+              }
+            },
+            {
+              "name": "timestamp",
+              "type": [
+                "null",
+                {
+                  "logicalType": "timestamp-millis",
+                  "type": "long"
+                }
+              ],
+              "doc": "The UTC time stamp in milliseconds since Unix epoch (January 1, 1970 midnight) when the record data is generated.",
+              "default": null
+            },
+            {
+              "name": "interface_name",
+              "type": [
+                "null",
+                "string"
+              ],
+              "doc": "Indicates the name of the interface the device is connected. TR-181 object Device.Hosts.Host.{i}.Layer1Interface",
+              "default": null
+            },
+            {
+              "name": "status",
+              "type": [
+                "null",
+                {
+                  "doc": "Status of the connected device",
+                  "name": "NetworkDeviceStatus",
+                  "namespace": "com.comcast.kestrel.odp.datatype",
+                  "symbols": [
+                    "ONLINE",
+                    "OFFLINE"
+                  ],
+                  "type": "enum"
+                }
+              ],
+              "doc": "Indicates the current status of the 'connected' device. [TR-181: Commonly found in Device.WiFi.AccessPoint.{i}.AssociatedDevice.{i}.Active, OR Device.(InterfaceType).Interface.{i}.AssociatedDevice.{i}.Active]",
+              "default": null
+            },
+            {
+              "name": "hostname",
+              "type": [
+                "null",
+                "string"
+              ],
+              "default":null
+            },
+            {
+              "name": "ip_addresses",
+              "type": [
+                "null",
+                {
+                  "type":"array",
+                  "items":"string"
+                }
+              ],
+              "default":null
+            },
+            {
+              "name": "mlo_used",
+              "type": [
+                "null",
+                "boolean"
+              ],
+              "doc": "Indicates whether MLO is used for the connected device. Set to true when the connected device is an MLO client, false when the device is confirmed to be a non-MLO client",
+              "default": null
+            },
+            {
+              "name": "mlo_bands",
+              "type": [
+                "null",
+                "string"
+              ],
+              "doc": "Comma-delimited list of MLO bands derived from Device.Hosts.Host.{i}.MloLink.{j}.X_RDK-Layer1Interface, for example 5GHz,6GHz.",
+              "default": null
+            },
+            {
+              "name": "mlo_mode",
+              "type": [
+                "null",
+                "string"
+              ],
+              "doc": "MLO mode for the connected device. Set to single when Device.Hosts.Host.{i}.X_RDK-MloLinkNumberofEntries = 1, and multi when Device.Hosts.Host.{i}.X_RDK-MloLinkNumberofEntries > 1.",
+              "default": null
+            }
+          ]
+        },
+        "type": "array"
+      }
+    }
+  ]
+}

--- a/source/lm/Makefile.am
+++ b/source/lm/Makefile.am
@@ -31,6 +31,7 @@ libCcspLM_la_SOURCES = cosa_hosts_dml.c \
                        lm_main.c \
                        lm_wrapper.c \
                        lm_util.c \
+                       lm_rbus_api.c \
                        network_devices_status_avropack.c  \
                        webpa_interface.c \
                        webpa_pd_with_seshat.c \

--- a/source/lm/lm_main.c
+++ b/source/lm/lm_main.c
@@ -3389,8 +3389,48 @@ void LM_main (void)
     CcspTraceWarning(("LMLite:rdk initialzed!\n"));
 
 if(checkRbusEnabled()) {
-        CcspTraceDebug(("RBUS mode. lmliteRbusInit\n"));
-	lmliteRbusInit(LMLITE_COMPONENT_NAME);  // Initiating the Rbus 
+        CcspTraceInfo(("RBUS mode. lmliteRbusInit\n"));
+    rbusError_t rbusRet;
+	rbusRet = lmliteRbusInit(LMLITE_COMPONENT_NAME);  // Initiating the Rbus
+    if(rbusRet == RBUS_ERROR_SUCCESS)
+    {
+        CcspTraceInfo((" %s: lmliteRbusInit success\n", __FUNCTION__));
+        if(regLMLiteDataModel() == 0)
+        {
+            CcspTraceInfo((" %s: lmLite Data Model registered successfully\n", __FUNCTION__));
+            /* Load initial value from PSM */
+            int ret = 0;
+            char *tmpchar = NULL;
+            ret = rbus_GetValueFromPsmDB(LMLITE_MLO_RFC_PARAM, &tmpchar);
+            if (ret == 0 && tmpchar != NULL)
+            {
+                if ((strcmp(tmpchar, "true") == 0) || (strcmp(tmpchar, "TRUE") == 0))
+                {
+                    set_lmLiteMLORfcEnable(true);
+                }
+                else
+                {
+                    set_lmLiteMLORfcEnable(false);
+                }
+                free(tmpchar);
+                CcspTraceInfo((" %s: Loaded MLO RFC value from PSM = %d\n", __FUNCTION__, get_lmLiteMLORfcEnable()));
+            }
+            else
+            {
+                /* Default to false if PSM value doesn't exist */
+                set_lmLiteMLORfcEnable(false);
+                CcspTraceWarning((" %s: MLO RFC PSM value not found, defaulting to false\n", __FUNCTION__));
+            }
+        }
+        else
+        {
+            CcspTraceError((" %s: lmLite Data Model registration failed\n", __FUNCTION__));
+        }
+    }
+    else
+    {
+        CcspTraceError((" %s: lmliteRbusInit failed with error code %d\n", __FUNCTION__, rbusRet));
+    }
 #ifdef WAN_FAILOVER_SUPPORTED
     set_rbus_handle();
 	get_WanManager_ActiveInterface();  
@@ -3410,37 +3450,6 @@ if(checkRbusEnabled()) {
 #endif
     CcspTraceInfo(("%s : WanTraffic Count Support ENABLED\n",__FUNCTION__));
     WTC_Init();
-    if(regLMLiteDataModel() == 0)
-    {
-        WTC_LOG_INFO(" %s: lmLite Data Model registered successfully\n", __FUNCTION__);
-    }
-    else
-    {
-        WTC_LOG_ERROR(" %s: lmLite Data Model registration failed\n", __FUNCTION__);
-    }
-    /* Load initial value from PSM */
-    rbusError_t ret = RBUS_ERROR_SUCCESS;
-    char *tmpchar = NULL;
-    ret = rbus_GetValueFromPsmDB(LMLITE_MLO_RFC_PARAM, &tmpchar);
-    if (ret == RBUS_ERROR_SUCCESS && tmpchar != NULL)
-    {
-        if ((strcmp(tmpchar, "true") == 0) || (strcmp(tmpchar, "TRUE") == 0))
-        {
-            set_lmLiteMLORfcEnable(true);
-        }
-        else
-        {
-            set_lmLiteMLORfcEnable(false);
-        }
-        free(tmpchar);
-        WTC_LOG_WARNING(" %s: Loaded MLO RFC value from PSM = %d\n", __FUNCTION__, get_lmLiteMLORfcEnable());
-    }
-    else
-    {
-        /* Default to false if PSM value doesn't exist */
-        set_lmLiteMLORfcEnable(false);
-        WTC_LOG_WARNING(" %s: MLO RFC PSM value not found, defaulting to false\n", __FUNCTION__);
-    }
 #if defined (RDKB_EXTENDER_ENABLED)
     }
 #endif

--- a/source/lm/lm_main.c
+++ b/source/lm/lm_main.c
@@ -77,6 +77,7 @@
 #ifdef WAN_TRAFFIC_COUNT_SUPPORT
 #include "cosa_wantraffic_api.h"
 #endif
+#include "lm_rbus_api.h"
 #include "webpa_interface.h"
 #include "lm_wrapper.h"
 #include "lm_api.h"
@@ -3387,14 +3388,15 @@ void LM_main (void)
 #endif
     CcspTraceWarning(("LMLite:rdk initialzed!\n"));
 
-#ifdef WAN_FAILOVER_SUPPORTED
-    if(checkRbusEnabled()) {
+if(checkRbusEnabled()) {
         CcspTraceDebug(("RBUS mode. lmliteRbusInit\n"));
 	lmliteRbusInit(LMLITE_COMPONENT_NAME);  // Initiating the Rbus 
+#ifdef WAN_FAILOVER_SUPPORTED
+    set_rbus_handle();
 	get_WanManager_ActiveInterface();  
 	subscribeTo_InterfaceActiveStatus_Event();  
-    }	     
 #endif
+}
     initparodusTask();
 
 #ifdef WAN_TRAFFIC_COUNT_SUPPORT
@@ -3408,6 +3410,37 @@ void LM_main (void)
 #endif
     CcspTraceInfo(("%s : WanTraffic Count Support ENABLED\n",__FUNCTION__));
     WTC_Init();
+    if(regLMLiteDataModel() == 0)
+    {
+        WTC_LOG_INFO(" %s: lmLite Data Model registered successfully\n", __FUNCTION__);
+    }
+    else
+    {
+        WTC_LOG_ERROR(" %s: lmLite Data Model registration failed\n", __FUNCTION__);
+    }
+    /* Load initial value from PSM */
+    rbusError_t ret = RBUS_ERROR_SUCCESS;
+    char *tmpchar = NULL;
+    ret = rbus_GetValueFromPsmDB(LMLITE_MLO_RFC_PARAM, &tmpchar);
+    if (ret == RBUS_ERROR_SUCCESS && tmpchar != NULL)
+    {
+        if ((strcmp(tmpchar, "true") == 0) || (strcmp(tmpchar, "TRUE") == 0))
+        {
+            set_lmLiteMLORfcEnable(true);
+        }
+        else
+        {
+            set_lmLiteMLORfcEnable(false);
+        }
+        free(tmpchar);
+        WTC_LOG_WARNING(" %s: Loaded MLO RFC value from PSM = %d\n", __FUNCTION__, get_lmLiteMLORfcEnable());
+    }
+    else
+    {
+        /* Default to false if PSM value doesn't exist */
+        set_lmLiteMLORfcEnable(false);
+        WTC_LOG_WARNING(" %s: MLO RFC PSM value not found, defaulting to false\n", __FUNCTION__);
+    }
 #if defined (RDKB_EXTENDER_ENABLED)
     }
 #endif

--- a/source/lm/lm_rbus_api.c
+++ b/source/lm/lm_rbus_api.c
@@ -48,35 +48,31 @@ pthread_mutex_t g_mloRfcMutex = PTHREAD_MUTEX_INITIALIZER;
 static bool g_MLORfcEnabled = false;
 
 //Initiate Rbus
-rbusError_t lmliteRbusInit(const char *pComponentName)
+rbusError_t lmliteRbusInit(char const* pRbusComponentName)
 {
-	int ret = RBUS_ERROR_SUCCESS;
-    CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, rbus_open for component %s\n", pComponentName));
-	ret = rbus_open(&rbus_handle, pComponentName);
-	if(ret != RBUS_ERROR_SUCCESS)
-	{
-		CcspLMLiteConsoleTrace(("RDK_LOG_ERROR, LMLiteRbusInit failed with error code %d\n", ret));
-		return ret;
-	}
-	CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, LMLiteRbusInit is success. ret is %d\n", ret));
-	return ret;
+    rbusError_t ret = RBUS_ERROR_SUCCESS;
+    CcspTraceInfo(("rbus_open for component %s\n", pRbusComponentName));
+    CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, rbus_open for component %s\n", pRbusComponentName));
+    ret = rbus_open(&rbus_handle, pRbusComponentName);
+    if(ret != RBUS_ERROR_SUCCESS)
+    {
+        CcspTraceError(("LMLiteRbusInit failed with error code %d\n", ret));
+        return ret;
+    }
+    CcspTraceInfo(("LMLiteRbusInit is success. ret is %d\n", ret));
+    return ret;
 }
 
 //Checking the Rbus active status
-bool checkRbusEnabled()
+bool checkRbusEnabled(void)
 {
-    int isRbus = RBUS_ERROR_SUCCESS;
-    
+    bool isRbus = false;
     if(RBUS_ENABLED == rbus_checkStatus())
-	{
-		isRbus = true;
-	}
-	else
-	{
-		isRbus = false;
-	}
-	CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, LMLite RBUS mode active status = %s\n", isRbus ? "true":"false"));
-	return isRbus;
+    {
+        isRbus = true;
+    }
+    CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, LMLite RBUS mode active status = %s\n", isRbus ? "true":"false"));
+    return isRbus;
 }
 
 rbusHandle_t get_rbus_handle(void)
@@ -87,17 +83,16 @@ rbusHandle_t get_rbus_handle(void)
 /**
  * To persist TR181 parameter values in PSM DB.
  */
-int rbus_StoreValueIntoPsmDB(char *paramName, char *value)
+int rbus_StoreValueIntoPsmDB(char const* paramName, char const* value)
 {
-    rbusHandle_t rbus_handle = get_rbus_handle();
     rbusObject_t inParams;
     rbusObject_t outParams;
     rbusValue_t setvalue;
-    int rc = RBUS_ERROR_SUCCESS;
+    rbusError_t rc = RBUS_ERROR_SUCCESS;
 
     if(!rbus_handle)
     {
-        CcspLMLiteConsoleTrace(("RDK_LOG_ERROR, %s: failed as rbus_handle is empty\n", __FUNCTION__));
+        CcspTraceError(("%s: failed as rbus_handle is empty\n", __FUNCTION__));
         return 1;
     }
 
@@ -111,7 +106,7 @@ int rbus_StoreValueIntoPsmDB(char *paramName, char *value)
     rbusObject_Release(inParams);
     if(rc != RBUS_ERROR_SUCCESS)
     {
-        CcspLMLiteConsoleTrace(("RDK_LOG_ERROR, %s: SetPSMRecordValue failed with err %d: %s\n", __FUNCTION__, rc, rbusError_ToString(rc)));
+        CcspTraceError(("%s: SetPSMRecordValue failed with err %d: %s\n", __FUNCTION__, rc, rbusError_ToString(rc)));
     }
     else
     {
@@ -125,17 +120,16 @@ int rbus_StoreValueIntoPsmDB(char *paramName, char *value)
 /**
  * To fetch TR181 parameter values from PSM DB.
  */
-int rbus_GetValueFromPsmDB( char* paramName, char** paramValue)
+int rbus_GetValueFromPsmDB(char const* paramName, char** paramValue)
 {
-    rbusHandle_t rbus_handle = get_rbus_handle();
     rbusObject_t inParams;
     rbusObject_t outParams;
     rbusValue_t setvalue;
-    int rc = RBUS_ERROR_SUCCESS;
+    rbusError_t rc = RBUS_ERROR_SUCCESS;
 
     if(!rbus_handle)
     {
-        CcspLMLiteConsoleTrace(("RDK_LOG_ERROR, %s: failed as rbus_handle is empty\n", __FUNCTION__));
+        CcspTraceError(("%s: failed as rbus_handle is empty\n", __FUNCTION__));
         return 1;
     }
 
@@ -149,20 +143,25 @@ int rbus_GetValueFromPsmDB( char* paramName, char** paramValue)
     rbusObject_Release(inParams);
     if(rc != RBUS_ERROR_SUCCESS)
     {
-        CcspLMLiteConsoleTrace(("RDK_LOG_ERROR, %s: GetPSMRecordValue failed with err %d: %s\n", __FUNCTION__, rc, rbusError_ToString(rc)));
+        CcspTraceError(("%s: GetPSMRecordValue failed with err %d: %s\n", __FUNCTION__, rc, rbusError_ToString(rc)));
     }
     else
     {
         CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, %s: GetPSMRecordValue is success\n", __FUNCTION__));
         rbusProperty_t prop = NULL;
         rbusValue_t value = NULL;
-        const char *str_value = NULL;
+        char *str_value = NULL;
         prop = rbusObject_GetProperties(outParams);
         while(prop)
         {
             value = rbusProperty_GetValue(prop);
             if(value)
             {
+                /* Free previous str_value before overwriting to avoid resource leak*/
+                if(str_value)
+                {
+                    free(str_value);
+                }
                 str_value = rbusValue_ToString(value,NULL,0);
                 if(str_value)
                 {
@@ -175,9 +174,11 @@ int rbus_GetValueFromPsmDB( char* paramName, char** paramValue)
         if(str_value != NULL)
         {
             *paramValue = strdup(str_value);
+            free(str_value);
+            str_value = NULL;
             if(*paramValue == NULL)
             {
-                CcspLMLiteConsoleTrace(("RDK_LOG_ERROR, %s: strdup failed for parameter value\n", __FUNCTION__));
+                CcspTraceError(("%s: strdup failed for parameter value\n", __FUNCTION__));
                 rbusObject_Release(outParams);
                 return 1;
             }
@@ -185,6 +186,8 @@ int rbus_GetValueFromPsmDB( char* paramName, char** paramValue)
             rbusObject_Release(outParams);
             return 0;
         }
+        /* No property value found: release outParams to avoid resource leak*/
+        rbusObject_Release(outParams);
     }
     return 1;
 }
@@ -195,21 +198,15 @@ int rbus_GetValueFromPsmDB( char* paramName, char** paramValue)
 int set_lmLiteMLORfcEnable(bool bValue)
 {
     // Update PSM DB Value
-    rbusError_t retPsmSet = RBUS_ERROR_SUCCESS;
+    int retPsmSet = 0;
     char *buf = NULL;
 
-    buf = bValue ? strdup("true") : strdup("false");
-    if (buf == NULL)
-    {
-        CcspLMLiteConsoleTrace(("RDK_LOG_ERROR, %s: strdup failed\n", __FUNCTION__));
-        return 1;
-    }
+    buf = bValue ? "true" : "false";
 
     retPsmSet = rbus_StoreValueIntoPsmDB(LMLITE_MLO_RFC_PARAM, buf);
-    if (retPsmSet != RBUS_ERROR_SUCCESS)
+    if (retPsmSet != 0)
     {
-        CcspLMLiteConsoleTrace(("RDK_LOG_ERROR, %s: PSM set failed ret %d for parameter %s and value %s\n", __FUNCTION__, retPsmSet, LMLITE_MLO_RFC_PARAM, buf));
-        free(buf);
+        CcspTraceError((" %s: PSM set failed ret %d for parameter %s and value %s\n", __FUNCTION__, retPsmSet, LMLITE_MLO_RFC_PARAM, buf));
         return 1;
     }
     CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, %s: PSM set success for parameter %s and value %s\n", __FUNCTION__, LMLITE_MLO_RFC_PARAM, buf));
@@ -220,13 +217,12 @@ int set_lmLiteMLORfcEnable(bool bValue)
     pthread_mutex_unlock(&g_mloRfcMutex);
     if(bValue == true)
     {
-        CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, %s: lmLite MLO RFC is enabled\n", __FUNCTION__));
+        CcspTraceInfo(("lmLite MLO RFC is enabled\n"));
     }
     else
     {
-        CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, %s: lmLite MLO RFC is disabled\n", __FUNCTION__));
+        CcspTraceInfo(("lmLite MLO RFC is disabled\n"));
     }
-    free(buf);
     return 0;
 }
 
@@ -253,7 +249,7 @@ static rbusError_t lmLiteMLO_RfcSetHandler(rbusHandle_t handle, rbusProperty_t p
     propertyName = rbusProperty_GetName(prop);
     if (propertyName == NULL)
     {
-        CcspLMLiteConsoleTrace(("RDK_LOG_ERROR, %s: Unable to handle set request for property\n", __FUNCTION__));
+        CcspTraceError(("%s: Unable to handle set request for property\n", __FUNCTION__));
         return RBUS_ERROR_INVALID_INPUT;
     }
 
@@ -261,7 +257,7 @@ static rbusError_t lmLiteMLO_RfcSetHandler(rbusHandle_t handle, rbusProperty_t p
 
     if (strcmp(propertyName, LMLITE_MLO_RFC_PARAM) != 0)
     {
-        CcspLMLiteConsoleTrace(("RDK_LOG_ERROR, %s: Unexpected parameter %s\n", __FUNCTION__, propertyName));
+        CcspTraceError(("%s: Unexpected parameter %s\n", __FUNCTION__, propertyName));
         return RBUS_ERROR_ELEMENT_DOES_NOT_EXIST;
     }
     
@@ -271,14 +267,14 @@ static rbusError_t lmLiteMLO_RfcSetHandler(rbusHandle_t handle, rbusProperty_t p
     paramValue_t = rbusProperty_GetValue(prop);
     if (paramValue_t == NULL)
     {
-        CcspLMLiteConsoleTrace(("RDK_LOG_ERROR, %s: value is NULL\n", __FUNCTION__));
+        CcspTraceError(("%s: value is NULL\n", __FUNCTION__));
         return RBUS_ERROR_INVALID_INPUT;
     }
 
     type = rbusValue_GetType(paramValue_t);
     if (type != RBUS_BOOLEAN)
     {
-        CcspLMLiteConsoleTrace(("RDK_LOG_ERROR, %s: Unexpected value type %d\n", __FUNCTION__, type));
+        CcspTraceError(("%s: Unexpected value type %d\n", __FUNCTION__, type));
         return RBUS_ERROR_INVALID_INPUT;
     }
 
@@ -286,12 +282,11 @@ static rbusError_t lmLiteMLO_RfcSetHandler(rbusHandle_t handle, rbusProperty_t p
     CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, %s: Setting MLO RFC to %s\n", __FUNCTION__, paramVal ? "true" : "false"));
 
     if (set_lmLiteMLORfcEnable(paramVal) != 0) {
-        CcspLMLiteConsoleTrace(("RDK_LOG_ERROR, %s: set_lmLiteMLORfcEnable failed\n", __FUNCTION__));
+        CcspTraceError(("%s: set_lmLiteMLORfcEnable failed\n", __FUNCTION__));
         return RBUS_ERROR_BUS_ERROR;
     }
 
-    CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, %s: MLO RFC set successfully to %s\n", 
-                        __FUNCTION__, paramVal ? "true" : "false"));
+    CcspTraceInfo(("MLO RFC set successfully to %s\n", paramVal ? "true" : "false"));
     return RBUS_ERROR_SUCCESS;
 }
 
@@ -307,7 +302,7 @@ static rbusError_t lmLiteMLO_RfcGetHandler(rbusHandle_t handle, rbusProperty_t p
     propertyName = rbusProperty_GetName(property);
     if (propertyName == NULL)
     {
-        CcspLMLiteConsoleTrace(("RDK_LOG_ERROR, %s: Unable to handle get request for property\n", __FUNCTION__));
+        CcspTraceError(("%s: Unable to handle get request for property\n", __FUNCTION__));
         return RBUS_ERROR_INVALID_INPUT;
     }
 
@@ -315,11 +310,11 @@ static rbusError_t lmLiteMLO_RfcGetHandler(rbusHandle_t handle, rbusProperty_t p
 
     if (strcmp(propertyName, LMLITE_MLO_RFC_PARAM) != 0)
     {
-        CcspLMLiteConsoleTrace(("RDK_LOG_ERROR, %s: Unexpected parameter %s\n", __FUNCTION__, propertyName));
+        CcspTraceError(("%s: Unexpected parameter %s\n", __FUNCTION__, propertyName));
         return RBUS_ERROR_ELEMENT_DOES_NOT_EXIST;
     }
 
-    rbusError_t retPsmGet = RBUS_ERROR_SUCCESS;
+    int retPsmGet = 0;
     rbusValue_t value;
     bool mloRfcEnabled = false;
 
@@ -327,7 +322,7 @@ static rbusError_t lmLiteMLO_RfcGetHandler(rbusHandle_t handle, rbusProperty_t p
 
     /* Get value from PSM DB */
     retPsmGet = rbus_GetValueFromPsmDB(LMLITE_MLO_RFC_PARAM, &tmpchar);
-    if (retPsmGet == RBUS_ERROR_SUCCESS)
+    if (retPsmGet == 0)
     {
       if (tmpchar != NULL)
       {
@@ -374,29 +369,28 @@ static rbusError_t lmLiteMLO_RfcGetHandler(rbusHandle_t handle, rbusProperty_t p
  * @brief Initialize and register MLO RFC RBUS data elements
  * @return 0 for success, -1 for failure
  */
-int regLMLiteDataModel()
+int regLMLiteDataModel(void)
 {
     rbusError_t ret = RBUS_ERROR_SUCCESS;
-    rbusHandle_t handle = get_rbus_handle();
 
-
-    if (handle == NULL)
+    if (rbus_handle == NULL)
     {
-        CcspLMLiteConsoleTrace(("RDK_LOG_ERROR, %s: rbus handle is NULL\n", __FUNCTION__));
+        CcspTraceError((" %s: rbus handle is NULL\n", __FUNCTION__));
         return -1;
     }
 
-    CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, %s: Registering MLO RFC parameter %s\n", __FUNCTION__, LMLITE_MLO_RFC_PARAM));
+    CcspTraceInfo(("Registering MLO RFC parameter %s\n", LMLITE_MLO_RFC_PARAM));
+    CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, Registering MLO RFC parameter %s \n", LMLITE_MLO_RFC_PARAM));
 
     rbusDataElement_t dataElements[1] = {
       {LMLITE_MLO_RFC_PARAM, RBUS_ELEMENT_TYPE_PROPERTY, {lmLiteMLO_RfcGetHandler, lmLiteMLO_RfcSetHandler, NULL, NULL, NULL, NULL}}
     };
 
-    ret = rbus_regDataElements(handle, 1, dataElements);
+    ret = rbus_regDataElements(rbus_handle, 1, dataElements);
 
     if (ret != RBUS_ERROR_SUCCESS)
     {
-        CcspLMLiteConsoleTrace(("RDK_LOG_ERROR, %s: rbus_regDataElements failed with error %d\n", __FUNCTION__, ret));
+        CcspTraceError((" %s: rbus_regDataElements failed with error %d\n", __FUNCTION__, ret));
         return -1;
     }
     return 0;
@@ -404,15 +398,36 @@ int regLMLiteDataModel()
 
 char* GetRbusString(const char* param)
 {
-    char* value = NULL;
+    rbusValue_t value = NULL;
+    char* newValue = NULL;
+
+    CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, LMLite %s param=%s\n", __FUNCTION__, param ? param : "NULL"));
 
     if (!param)
-        return NULL;
-
-    if (rbus_getStr(rbus_handle, param, &value) != RBUS_ERROR_SUCCESS)
     {
+        CcspTraceError(("LMLite %s param is NULL\n", __FUNCTION__));
         return NULL;
     }
 
-    return value;
+    if (rbus_handle == NULL)
+    {
+        CcspTraceError((" %s: rbus handle is NULL\n", __FUNCTION__));
+        return NULL;
+    }
+
+    if (rbus_get(rbus_handle, param, &value) != RBUS_ERROR_SUCCESS)
+    {
+        CcspTraceError(("LMLite %s rbus_get failed for param=%s\n", __FUNCTION__, param));
+        return NULL;
+    }
+
+    newValue = rbusValue_ToString(value, NULL, 0);
+    if(newValue == NULL)
+    {
+        CcspTraceError(("LMLite %s rbusValue_ToString failed for param=%s\n", __FUNCTION__, param));
+    }
+    CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, LMLite %s value=%s\n", __FUNCTION__, newValue ? newValue : "NULL"));
+
+    rbusValue_Release(value);
+    return newValue;
 }

--- a/source/lm/lm_rbus_api.c
+++ b/source/lm/lm_rbus_api.c
@@ -1,0 +1,418 @@
+/*
+ * If not stated otherwise in this file or this component's Licenses.txt file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2026 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+/**********************************************************************
+   Copyright [2026] [Cisco Systems, Inc.]
+ 
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+ 
+       http://www.apache.org/licenses/LICENSE-2.0
+ 
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+**********************************************************************/
+#include "lm_rbus_api.h"
+#include "ccsp_lmliteLog_wrapper.h"
+#include "ansc_platform.h"
+#include <pthread.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdbool.h>
+
+static rbusHandle_t rbus_handle;
+
+pthread_mutex_t g_mloRfcMutex = PTHREAD_MUTEX_INITIALIZER;
+
+/* Global variable for MLO RFC enable status */
+static bool g_MLORfcEnabled = false;
+
+//Initiate Rbus
+rbusError_t lmliteRbusInit(const char *pComponentName)
+{
+	int ret = RBUS_ERROR_SUCCESS;
+    CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, rbus_open for component %s\n", pComponentName));
+	ret = rbus_open(&rbus_handle, pComponentName);
+	if(ret != RBUS_ERROR_SUCCESS)
+	{
+		CcspLMLiteConsoleTrace(("RDK_LOG_ERROR, LMLiteRbusInit failed with error code %d\n", ret));
+		return ret;
+	}
+	CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, LMLiteRbusInit is success. ret is %d\n", ret));
+	return ret;
+}
+
+//Checking the Rbus active status
+bool checkRbusEnabled()
+{
+    int isRbus = RBUS_ERROR_SUCCESS;
+    
+    if(RBUS_ENABLED == rbus_checkStatus())
+	{
+		isRbus = true;
+	}
+	else
+	{
+		isRbus = false;
+	}
+	CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, LMLite RBUS mode active status = %s\n", isRbus ? "true":"false"));
+	return isRbus;
+}
+
+rbusHandle_t get_rbus_handle(void)
+{
+    return rbus_handle;
+}
+
+/**
+ * To persist TR181 parameter values in PSM DB.
+ */
+int rbus_StoreValueIntoPsmDB(char *paramName, char *value)
+{
+    rbusHandle_t rbus_handle = get_rbus_handle();
+    rbusObject_t inParams;
+    rbusObject_t outParams;
+    rbusValue_t setvalue;
+    int rc = RBUS_ERROR_SUCCESS;
+
+    if(!rbus_handle)
+    {
+        CcspLMLiteConsoleTrace(("RDK_LOG_ERROR, %s: failed as rbus_handle is empty\n", __FUNCTION__));
+        return 1;
+    }
+
+    rbusObject_Init(&inParams, NULL);
+    rbusValue_Init(&setvalue);
+    rbusValue_SetString(setvalue, value);
+    rbusObject_SetValue(inParams, paramName, setvalue);
+    rbusValue_Release(setvalue);
+
+    rc = rbusMethod_Invoke(rbus_handle, "SetPSMRecordValue()", inParams, &outParams);
+    rbusObject_Release(inParams);
+    if(rc != RBUS_ERROR_SUCCESS)
+    {
+        CcspLMLiteConsoleTrace(("RDK_LOG_ERROR, %s: SetPSMRecordValue failed with err %d: %s\n", __FUNCTION__, rc, rbusError_ToString(rc)));
+    }
+    else
+    {
+        CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, %s: SetPSMRecordValue is success\n", __FUNCTION__));
+        rbusObject_Release(outParams);
+        return 0;
+    }
+    return 1;
+}
+
+/**
+ * To fetch TR181 parameter values from PSM DB.
+ */
+int rbus_GetValueFromPsmDB( char* paramName, char** paramValue)
+{
+    rbusHandle_t rbus_handle = get_rbus_handle();
+    rbusObject_t inParams;
+    rbusObject_t outParams;
+    rbusValue_t setvalue;
+    int rc = RBUS_ERROR_SUCCESS;
+
+    if(!rbus_handle)
+    {
+        CcspLMLiteConsoleTrace(("RDK_LOG_ERROR, %s: failed as rbus_handle is empty\n", __FUNCTION__));
+        return 1;
+    }
+
+    rbusObject_Init(&inParams, NULL);
+    rbusValue_Init(&setvalue);
+    rbusValue_SetString(setvalue, "value");
+    rbusObject_SetValue(inParams, paramName, setvalue);
+    rbusValue_Release(setvalue);
+
+    rc = rbusMethod_Invoke(rbus_handle, "GetPSMRecordValue()", inParams, &outParams);
+    rbusObject_Release(inParams);
+    if(rc != RBUS_ERROR_SUCCESS)
+    {
+        CcspLMLiteConsoleTrace(("RDK_LOG_ERROR, %s: GetPSMRecordValue failed with err %d: %s\n", __FUNCTION__, rc, rbusError_ToString(rc)));
+    }
+    else
+    {
+        CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, %s: GetPSMRecordValue is success\n", __FUNCTION__));
+        rbusProperty_t prop = NULL;
+        rbusValue_t value = NULL;
+        const char *str_value = NULL;
+        prop = rbusObject_GetProperties(outParams);
+        while(prop)
+        {
+            value = rbusProperty_GetValue(prop);
+            if(value)
+            {
+                str_value = rbusValue_ToString(value,NULL,0);
+                if(str_value)
+                {
+                    CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, %s: Parameter Name : %s\n", __FUNCTION__, rbusProperty_GetName(prop)));
+                    CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, %s: Parameter Value fetched: %s\n", __FUNCTION__, str_value));
+                }
+            }
+            prop = rbusProperty_GetNext(prop);
+        }
+        if(str_value != NULL)
+        {
+            *paramValue = strdup(str_value);
+            if(*paramValue == NULL)
+            {
+                CcspLMLiteConsoleTrace(("RDK_LOG_ERROR, %s: strdup failed for parameter value\n", __FUNCTION__));
+                rbusObject_Release(outParams);
+                return 1;
+            }
+            CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, %s: Requested param DB value [%s]\n", __FUNCTION__, *paramValue));
+            rbusObject_Release(outParams);
+            return 0;
+        }
+    }
+    return 1;
+}
+
+/**
+ * @brief Set MLO RFC enable status and persist to PSM
+ */
+int set_lmLiteMLORfcEnable(bool bValue)
+{
+    // Update PSM DB Value
+    rbusError_t retPsmSet = RBUS_ERROR_SUCCESS;
+    char *buf = NULL;
+
+    buf = bValue ? strdup("true") : strdup("false");
+    if (buf == NULL)
+    {
+        CcspLMLiteConsoleTrace(("RDK_LOG_ERROR, %s: strdup failed\n", __FUNCTION__));
+        return 1;
+    }
+
+    retPsmSet = rbus_StoreValueIntoPsmDB(LMLITE_MLO_RFC_PARAM, buf);
+    if (retPsmSet != RBUS_ERROR_SUCCESS)
+    {
+        CcspLMLiteConsoleTrace(("RDK_LOG_ERROR, %s: PSM set failed ret %d for parameter %s and value %s\n", __FUNCTION__, retPsmSet, LMLITE_MLO_RFC_PARAM, buf));
+        free(buf);
+        return 1;
+    }
+    CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, %s: PSM set success for parameter %s and value %s\n", __FUNCTION__, LMLITE_MLO_RFC_PARAM, buf));
+
+    /* Update global MLO RFC variable under mutex to avoid data races */
+    pthread_mutex_lock(&g_mloRfcMutex);
+    g_MLORfcEnabled = bValue;
+    pthread_mutex_unlock(&g_mloRfcMutex);
+    if(bValue == true)
+    {
+        CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, %s: lmLite MLO RFC is enabled\n", __FUNCTION__));
+    }
+    else
+    {
+        CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, %s: lmLite MLO RFC is disabled\n", __FUNCTION__));
+    }
+    free(buf);
+    return 0;
+}
+
+/**
+ * @brief Get MLO RFC enable status
+ */
+bool get_lmLiteMLORfcEnable(void)
+{
+    bool isRfc = false;
+    pthread_mutex_lock(&g_mloRfcMutex);
+    isRfc = g_MLORfcEnabled;
+    pthread_mutex_unlock(&g_mloRfcMutex);
+    return isRfc;
+}
+
+/**
+ * @brief RBUS Set handler for MLO RFC parameter
+ */
+static rbusError_t lmLiteMLO_RfcSetHandler(rbusHandle_t handle, rbusProperty_t prop, rbusSetHandlerOptions_t* opts)
+{
+    (void)handle;
+    (void)opts;
+    const char *propertyName;
+    propertyName = rbusProperty_GetName(prop);
+    if (propertyName == NULL)
+    {
+        CcspLMLiteConsoleTrace(("RDK_LOG_ERROR, %s: Unable to handle set request for property\n", __FUNCTION__));
+        return RBUS_ERROR_INVALID_INPUT;
+    }
+
+    CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, %s: Property Name is %s\n", __FUNCTION__, propertyName));
+
+    if (strcmp(propertyName, LMLITE_MLO_RFC_PARAM) != 0)
+    {
+        CcspLMLiteConsoleTrace(("RDK_LOG_ERROR, %s: Unexpected parameter %s\n", __FUNCTION__, propertyName));
+        return RBUS_ERROR_ELEMENT_DOES_NOT_EXIST;
+    }
+    
+    rbusValue_t paramValue_t = NULL;
+    rbusValueType_t type;
+
+    paramValue_t = rbusProperty_GetValue(prop);
+    if (paramValue_t == NULL)
+    {
+        CcspLMLiteConsoleTrace(("RDK_LOG_ERROR, %s: value is NULL\n", __FUNCTION__));
+        return RBUS_ERROR_INVALID_INPUT;
+    }
+
+    type = rbusValue_GetType(paramValue_t);
+    if (type != RBUS_BOOLEAN)
+    {
+        CcspLMLiteConsoleTrace(("RDK_LOG_ERROR, %s: Unexpected value type %d\n", __FUNCTION__, type));
+        return RBUS_ERROR_INVALID_INPUT;
+    }
+
+    bool paramVal = rbusValue_GetBoolean(paramValue_t);
+    CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, %s: Setting MLO RFC to %s\n", __FUNCTION__, paramVal ? "true" : "false"));
+
+    if (set_lmLiteMLORfcEnable(paramVal) != 0) {
+        CcspLMLiteConsoleTrace(("RDK_LOG_ERROR, %s: set_lmLiteMLORfcEnable failed\n", __FUNCTION__));
+        return RBUS_ERROR_BUS_ERROR;
+    }
+
+    CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, %s: MLO RFC set successfully to %s\n", 
+                        __FUNCTION__, paramVal ? "true" : "false"));
+    return RBUS_ERROR_SUCCESS;
+}
+
+/**
+ * @brief RBUS Get handler for MLO RFC parameter
+ */
+static rbusError_t lmLiteMLO_RfcGetHandler(rbusHandle_t handle, rbusProperty_t property, rbusGetHandlerOptions_t* opts)
+{
+    (void)handle;
+    (void)opts;
+
+    const char *propertyName;
+    propertyName = rbusProperty_GetName(property);
+    if (propertyName == NULL)
+    {
+        CcspLMLiteConsoleTrace(("RDK_LOG_ERROR, %s: Unable to handle get request for property\n", __FUNCTION__));
+        return RBUS_ERROR_INVALID_INPUT;
+    }
+
+    CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, %s: Property Name is %s\n", __FUNCTION__, propertyName));
+
+    if (strcmp(propertyName, LMLITE_MLO_RFC_PARAM) != 0)
+    {
+        CcspLMLiteConsoleTrace(("RDK_LOG_ERROR, %s: Unexpected parameter %s\n", __FUNCTION__, propertyName));
+        return RBUS_ERROR_ELEMENT_DOES_NOT_EXIST;
+    }
+
+    rbusError_t retPsmGet = RBUS_ERROR_SUCCESS;
+    rbusValue_t value;
+    bool mloRfcEnabled = false;
+
+    char *tmpchar = NULL;
+
+    /* Get value from PSM DB */
+    retPsmGet = rbus_GetValueFromPsmDB(LMLITE_MLO_RFC_PARAM, &tmpchar);
+    if (retPsmGet == RBUS_ERROR_SUCCESS)
+    {
+      if (tmpchar != NULL)
+      {
+          if ((strcmp(tmpchar, "true") == 0) || (strcmp(tmpchar, "TRUE") == 0))
+          {
+            pthread_mutex_lock(&g_mloRfcMutex);
+            g_MLORfcEnabled = true;
+            pthread_mutex_unlock(&g_mloRfcMutex);
+          }
+          else
+          {
+            pthread_mutex_lock(&g_mloRfcMutex);
+            g_MLORfcEnabled = false;
+            pthread_mutex_unlock(&g_mloRfcMutex);
+          }
+          CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, %s: MLO RFC value from PSM = %s\n", __FUNCTION__, tmpchar));
+          free(tmpchar);
+      }
+    }
+    else
+    {
+        if (tmpchar)
+            free(tmpchar);
+        pthread_mutex_lock(&g_mloRfcMutex);
+        CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, %s: PSM get failed ret %d, using cached value %d\n",__FUNCTION__, retPsmGet, g_MLORfcEnabled));
+        pthread_mutex_unlock(&g_mloRfcMutex);
+    }
+
+    /* Use cached in-memory value; PSM is read at init and on set */
+    pthread_mutex_lock(&g_mloRfcMutex);
+    mloRfcEnabled = g_MLORfcEnabled;
+    pthread_mutex_unlock(&g_mloRfcMutex);
+
+    rbusValue_Init(&value);
+    rbusValue_SetBoolean(value, mloRfcEnabled);
+    rbusProperty_SetValue(property, value);
+    rbusValue_Release(value);
+
+    CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, %s: Mlo Rfc value fetched is %s\n", __FUNCTION__, mloRfcEnabled ? "true" : "false"));
+    return RBUS_ERROR_SUCCESS;
+}
+
+/**
+ * @brief Initialize and register MLO RFC RBUS data elements
+ * @return 0 for success, -1 for failure
+ */
+int regLMLiteDataModel()
+{
+    rbusError_t ret = RBUS_ERROR_SUCCESS;
+    rbusHandle_t handle = get_rbus_handle();
+
+
+    if (handle == NULL)
+    {
+        CcspLMLiteConsoleTrace(("RDK_LOG_ERROR, %s: rbus handle is NULL\n", __FUNCTION__));
+        return -1;
+    }
+
+    CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, %s: Registering MLO RFC parameter %s\n", __FUNCTION__, LMLITE_MLO_RFC_PARAM));
+
+    rbusDataElement_t dataElements[1] = {
+      {LMLITE_MLO_RFC_PARAM, RBUS_ELEMENT_TYPE_PROPERTY, {lmLiteMLO_RfcGetHandler, lmLiteMLO_RfcSetHandler, NULL, NULL, NULL, NULL}}
+    };
+
+    ret = rbus_regDataElements(handle, 1, dataElements);
+
+    if (ret != RBUS_ERROR_SUCCESS)
+    {
+        CcspLMLiteConsoleTrace(("RDK_LOG_ERROR, %s: rbus_regDataElements failed with error %d\n", __FUNCTION__, ret));
+        return -1;
+    }
+    return 0;
+}
+
+char* GetRbusString(const char* param)
+{
+    char* value = NULL;
+
+    if (!param)
+        return NULL;
+
+    if (rbus_getStr(rbus_handle, param, &value) != RBUS_ERROR_SUCCESS)
+    {
+        return NULL;
+    }
+
+    return value;
+}

--- a/source/lm/lm_rbus_api.h
+++ b/source/lm/lm_rbus_api.h
@@ -1,0 +1,86 @@
+/*
+ * If not stated otherwise in this file or this component's Licenses.txt file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2026 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+/**********************************************************************
+   Copyright [2026] [Cisco Systems, Inc.]
+ 
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+ 
+       http://www.apache.org/licenses/LICENSE-2.0
+ 
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+**********************************************************************/
+
+#ifndef  _LM_RBUS_API_H_
+#define  _LM_RBUS_API_H_
+
+#include <rbus/rbus.h>
+#include <stdbool.h>
+
+#define LMLITE_COMPONENT_NAME "lmlite"
+bool checkRbusEnabled();
+rbusError_t lmliteRbusInit(const char *pComponentName);
+rbusHandle_t get_rbus_handle(void);
+#define LMLITE_MLO_RFC_PARAM "Device.DeviceInfo.X_RDKCENTRAL-COM_Report.NetworkDevicesStatus.MloRfcEnable"
+
+/**
+ * @brief Get MLO RFC enable status
+ * @return true if MLO lmLite is enabled, false otherwise
+ */
+bool get_lmLiteMLORfcEnable(void);
+
+/**
+ * @brief Set MLO RFC enable status and persist to PSM
+ * @return 0 on success, 1 on failure
+ */
+int set_lmLiteMLORfcEnable(bool bValue);
+
+/**
+ * To persist TR181 parameter values in PSM DB.
+ * @return status 0 for success or 1 for failure
+ */
+int rbus_StoreValueIntoPsmDB(char *paramName, char *value);
+
+/**
+ * To fetch TR181 parameter values from PSM DB.
+ * @return status 0 for success or 1 for failure
+ */
+int rbus_GetValueFromPsmDB( char* paramName, char** paramValue);
+
+/**
+ * @brief Gets the rbus_handle for lmLite.
+ *
+ * @return rbusHandle_t value
+ */
+rbusHandle_t get_rbus_handle(void);
+
+/**
+ * @brief Initialize and register MLO RFC RBUS data elements
+ * @return 0 for success, -1 for failure
+ */
+int regLMLiteDataModel(void);
+
+char* GetRbusString(const char* param);
+#endif

--- a/source/lm/lm_rbus_api.h
+++ b/source/lm/lm_rbus_api.h
@@ -40,9 +40,9 @@
 #include <stdbool.h>
 
 #define LMLITE_COMPONENT_NAME "lmlite"
-bool checkRbusEnabled();
-rbusError_t lmliteRbusInit(const char *pComponentName);
-rbusHandle_t get_rbus_handle(void);
+bool checkRbusEnabled(void);
+rbusError_t lmliteRbusInit(char const* pRbusComponentName);
+
 #define LMLITE_MLO_RFC_PARAM "Device.DeviceInfo.X_RDKCENTRAL-COM_Report.NetworkDevicesStatus.MloRfcEnable"
 
 /**
@@ -61,13 +61,17 @@ int set_lmLiteMLORfcEnable(bool bValue);
  * To persist TR181 parameter values in PSM DB.
  * @return status 0 for success or 1 for failure
  */
-int rbus_StoreValueIntoPsmDB(char *paramName, char *value);
+int rbus_StoreValueIntoPsmDB(char const* paramName, char const* value);
 
 /**
  * To fetch TR181 parameter values from PSM DB.
+ * @param[in] paramName   Fully qualified TR181 parameter name. Must not be NULL.
+ * @param[out] paramValue Heap-allocated string containing the parameter value on
+ *                        success. The caller is responsible for
+ *                        freeing the returned pointer.
  * @return status 0 for success or 1 for failure
  */
-int rbus_GetValueFromPsmDB( char* paramName, char** paramValue);
+int rbus_GetValueFromPsmDB(char const* paramName, char** paramValue);
 
 /**
  * @brief Gets the rbus_handle for lmLite.
@@ -82,5 +86,13 @@ rbusHandle_t get_rbus_handle(void);
  */
 int regLMLiteDataModel(void);
 
-char* GetRbusString(const char* param);
+/**
+ * @brief Get the string value of an RBUS parameter.
+ *
+ * @param[in] param  Fully qualified TR181 parameter name. Must not be NULL.
+ * @return           Heap-allocated string containing the parameter value on
+ *                   success, or NULL on failure. The caller is responsible for
+ *                   freeing the returned pointer.
+ */
+char* GetRbusString(char const* param);
 #endif

--- a/source/lm/network_devices_status.c
+++ b/source/lm/network_devices_status.c
@@ -412,44 +412,55 @@ static int _syscmd(FILE *f, char *retBuf, int retBufSize)
 #define MAX_PARAM_SIZE     256
 #define MAX_VALUE_SIZE     128
 #define MAX_BANDS_BUFFER   128
-static char* GetRbusString(const char* param)
-{
-    char* value = NULL;
-
-    if (!param)
-        return NULL;
-
-    if (rbus_getStr(handle, param, &value) != RBUS_ERROR_SUCCESS)
-    {
-        return NULL;
-    }
-
-    return value;
-}
-
 static void AppendBand(char* dst, size_t dstSize, const char* band)
 {
-    if (!dst || !band)
-        return;
-
-    if (strlen(dst) > 0)
+    if (!dst || !band || dstSize == 0)
     {
-        strncat(dst, ",", dstSize - strlen(dst) - 1);
+        CcspTraceError(("LMLite %s: invalid argument: dst=%p band=%p dstSize=%zu\n", __FUNCTION__, (void*)dst, (void*)band, dstSize));
+        return;
     }
 
-    strncat(dst, band, dstSize - strlen(dst) - 1);
+    size_t used = strlen(dst);
+    if (used >= dstSize - 1)
+    {
+        CcspTraceError(("LMLite %s: buffer full, cannot append band '%s' (used=%zu dstSize=%zu)\n", __FUNCTION__, band, used, dstSize));
+        return;
+    }
+
+    if (used > 0)
+    {
+        /* Re-read used after appending comma */
+        strncat(dst, ",", dstSize - used - 1);
+        used = strlen(dst);
+        if (used >= dstSize - 1)
+        {
+            CcspTraceError(("LMLite %s: buffer full after comma, cannot append band '%s' (used=%zu dstSize=%zu)\n", __FUNCTION__, band, used, dstSize));
+            return;
+        }
+    }
+
+    strncat(dst, band, dstSize - used - 1);
 }
 
-char* GetMLOBandsForHost(PLmObjectHost host)
+static char* GetMLOBandsForHost(PLmObjectHost host)
 {
     char* mlo_bands = NULL;
     char lowerLayerParam[MAX_PARAM_SIZE];
     char operBandParam[MAX_PARAM_SIZE];
     char bands[MAX_BANDS_BUFFER] = {0};
+
+    CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, LMLite %s ENTER\n", __FUNCTION__ ));
     
     char* ssidLowerLayer = NULL;
     char* operatingBand = NULL;
     PLmObjectMloLink link = NULL;
+
+    if (!host)
+    {
+        CcspTraceError(("LMLite %s NULL host\n", __FUNCTION__ ));
+        return NULL;
+    }
+
     link = host->mloLinkArray;
     while (link)
     {
@@ -459,26 +470,42 @@ char* GetMLOBandsForHost(PLmObjectHost host)
             ssidLowerLayer = GetRbusString(lowerLayerParam);
             if(ssidLowerLayer)
             {
-                snprintf(operBandParam,sizeof(operBandParam),"%s.OperatingFrequencyBand",ssidLowerLayer);
+                size_t ssidLowerLayerLen = strlen(ssidLowerLayer);
+                if (ssidLowerLayerLen > 0 && ssidLowerLayer[ssidLowerLayerLen - 1] == '.')
+                {
+                    snprintf(operBandParam, sizeof(operBandParam), "%sOperatingFrequencyBand", ssidLowerLayer);
+                }
+                else
+                {
+                    snprintf(operBandParam, sizeof(operBandParam), "%s.OperatingFrequencyBand", ssidLowerLayer);
+                }
                 operatingBand = GetRbusString(operBandParam);
                 if (operatingBand)
                 {
+                    CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, LMLite %s band=%s\n", __FUNCTION__, operatingBand ));
                     AppendBand(bands,sizeof(bands),operatingBand);
                     free(operatingBand);
-                    operatingBand = NULL;
                 }
 
                 free(ssidLowerLayer);
-                ssidLowerLayer = NULL;
             }
         }
         link = link->pNext;
     }
 
     if (bands[0] == '\0')
+    {
+        CcspTraceError(("LMLite %s EXIT: no bands found\n", __FUNCTION__ ));
         return NULL;
+    }
 
     mlo_bands = strdup(bands);
+    if(!mlo_bands)
+    {
+        CcspTraceError(("LMLite %s EXIT: strdup failed\n", __FUNCTION__ ));
+        return NULL;
+    }
+    CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, LMLite %s EXIT: mlo_bands=%s\n", __FUNCTION__, mlo_bands ));
     return mlo_bands;
 }
 
@@ -602,11 +629,43 @@ void add_to_list(PLmObjectHost host, struct networkdevicestatusdata **head)
     {
         ptr->device_mac = strdup(host->pStringParaValue[LM_HOST_PhysAddressId]);
         CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, DeviceMAC[%s] \n",ptr->device_mac ));
+        ptr->mlo_used = host->bBoolParaValue[LM_HOST_X_RDK_MldClientId];
+        if(ptr->mlo_used == true)
+        {
+            if(host->numMloLinks > 1)
+            {
+                ptr->mlo_mode = strdup("multi");
+                CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, Host has multiple MLO links [%d] \n",host->numMloLinks ));
+            }
+            else
+            {
+                ptr->mlo_mode = strdup("single");
+                CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, Host has single MLO link \n"));
+            }
 
-        if(host->pStringParaValue[LM_HOST_Layer1InterfaceId])
-                ptr->interface_name = strdup(host->pStringParaValue[LM_HOST_Layer1InterfaceId]);
-        else
+            ptr->mlo_bands = GetMLOBandsForHost(host);
+            CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, MLO Bands [%s] \n",ptr->mlo_bands ? ptr->mlo_bands : "NULL" ));
+
+            if(host->mloLinkArray && host->mloLinkArray->layer1Interface != NULL)
+            {
+                ptr->interface_name = strdup(host->mloLinkArray->layer1Interface);
+                CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, InterfaceName from MLO Link [%s] \n",ptr->interface_name ));
+            }
+            else
+            {
                 ptr->interface_name = strdup("Unknown");
+                CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, InterfaceName is NULL in MLO Link, set to Unknown \n"));
+            }
+        }
+        else
+        {
+            ptr->mlo_bands = NULL;
+            ptr->mlo_mode = NULL;
+            if(host->pStringParaValue[LM_HOST_Layer1InterfaceId])
+                ptr->interface_name = strdup(host->pStringParaValue[LM_HOST_Layer1InterfaceId]);
+            else
+                ptr->interface_name = strdup("Unknown");
+        }
 
         CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, InterfaceName[%s] \n",ptr->interface_name ));
         ptr->is_active = host->bBoolParaValue[LM_HOST_ActiveId];
@@ -643,31 +702,6 @@ void add_to_list(PLmObjectHost host, struct networkdevicestatusdata **head)
         ptr->ipaddress = NDS_GetIpAddress(host);;
 
         CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, IPAddress[%s] \n",ptr->ipaddress ));
-
-        if(host->numMloLinks > 0)
-        {
-            ptr->mlo_used = true;
-            if(host->numMloLinks > 1)
-            {
-                ptr->mlo_mode = strdup("multi");
-                CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, Host has multiple MLO links [%d] \n",host->numMloLinks ));
-            }
-            else
-            {
-                ptr->mlo_mode = strdup("single");
-                CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, Host has single MLO link \n"));
-            }
-
-            ptr->mlo_bands = GetMLOBandsForHost(host);
-            CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, MLO Bands [%s] \n",ptr->mlo_bands ? ptr->mlo_bands : "NULL" ));
-        }
-        else
-        {
-            ptr->mlo_used = false;
-            ptr->mlo_bands = NULL;
-            ptr->mlo_mode = NULL;
-        }
-
 
         if (*head == NULL)
         {

--- a/source/lm/network_devices_status.c
+++ b/source/lm/network_devices_status.c
@@ -39,6 +39,7 @@
 #include "webpa_interface.h"
 #include "safec_lib_common.h"
 #include "secure_wrapper.h"
+#include "lm_rbus_api.h"
 
 static pthread_mutex_t ndsMutex = PTHREAD_MUTEX_INITIALIZER;
 static pthread_cond_t ndsCond = PTHREAD_COND_INITIALIZER;
@@ -408,6 +409,78 @@ static int _syscmd(FILE *f, char *retBuf, int retBufSize)
     return 0;
 }
 #endif
+#define MAX_PARAM_SIZE     256
+#define MAX_VALUE_SIZE     128
+#define MAX_BANDS_BUFFER   128
+static char* GetRbusString(const char* param)
+{
+    char* value = NULL;
+
+    if (!param)
+        return NULL;
+
+    if (rbus_getStr(handle, param, &value) != RBUS_ERROR_SUCCESS)
+    {
+        return NULL;
+    }
+
+    return value;
+}
+
+static void AppendBand(char* dst, size_t dstSize, const char* band)
+{
+    if (!dst || !band)
+        return;
+
+    if (strlen(dst) > 0)
+    {
+        strncat(dst, ",", dstSize - strlen(dst) - 1);
+    }
+
+    strncat(dst, band, dstSize - strlen(dst) - 1);
+}
+
+char* GetMLOBandsForHost(PLmObjectHost host)
+{
+    char* mlo_bands = NULL;
+    char lowerLayerParam[MAX_PARAM_SIZE];
+    char operBandParam[MAX_PARAM_SIZE];
+    char bands[MAX_BANDS_BUFFER] = {0};
+    
+    char* ssidLowerLayer = NULL;
+    char* operatingBand = NULL;
+    PLmObjectMloLink link = NULL;
+    link = host->mloLinkArray;
+    while (link)
+    {
+        if (link->layer1Interface)
+        {
+            snprintf(lowerLayerParam,sizeof(lowerLayerParam),"%s.LowerLayers",link->layer1Interface);
+            ssidLowerLayer = GetRbusString(lowerLayerParam);
+            if(ssidLowerLayer)
+            {
+                snprintf(operBandParam,sizeof(operBandParam),"%s.OperatingFrequencyBand",ssidLowerLayer);
+                operatingBand = GetRbusString(operBandParam);
+                if (operatingBand)
+                {
+                    AppendBand(bands,sizeof(bands),operatingBand);
+                    free(operatingBand);
+                    operatingBand = NULL;
+                }
+
+                free(ssidLowerLayer);
+                ssidLowerLayer = NULL;
+            }
+        }
+        link = link->pNext;
+    }
+
+    if (bands[0] == '\0')
+        return NULL;
+
+    mlo_bands = strdup(bands);
+    return mlo_bands;
+}
 
 char* NDS_GetIpAddress(PLmObjectHost host)
 {
@@ -571,6 +644,30 @@ void add_to_list(PLmObjectHost host, struct networkdevicestatusdata **head)
 
         CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, IPAddress[%s] \n",ptr->ipaddress ));
 
+        if(host->numMloLinks > 0)
+        {
+            ptr->mlo_used = true;
+            if(host->numMloLinks > 1)
+            {
+                ptr->mlo_mode = strdup("multi");
+                CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, Host has multiple MLO links [%d] \n",host->numMloLinks ));
+            }
+            else
+            {
+                ptr->mlo_mode = strdup("single");
+                CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, Host has single MLO link \n"));
+            }
+
+            ptr->mlo_bands = GetMLOBandsForHost(host);
+            CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, MLO Bands [%s] \n",ptr->mlo_bands ? ptr->mlo_bands : "NULL" ));
+        }
+        else
+        {
+            ptr->mlo_used = false;
+            ptr->mlo_bands = NULL;
+            ptr->mlo_mode = NULL;
+        }
+
 
         if (*head == NULL)
         {
@@ -637,6 +734,16 @@ void delete_list(struct networkdevicestatusdata **head)
         currnode->hostname = NULL;
         free(currnode->ipaddress);
         currnode->ipaddress = NULL;
+        if(currnode->mlo_bands)
+        {
+            free(currnode->mlo_bands);
+            currnode->mlo_bands = NULL;
+        }
+        if(currnode->mlo_mode)
+        {
+            free(currnode->mlo_mode);
+            currnode->mlo_mode = NULL;
+        }
         free(currnode);
         currnode=NULL;
         currnode = next;

--- a/source/lm/network_devices_status_avropack.c
+++ b/source/lm/network_devices_status_avropack.c
@@ -38,6 +38,8 @@
 #include "mlt_malloc.h"
 #endif
 
+#include "lm_rbus_api.h"
+
 #define MAGIC_NUMBER      0x85
 #define MAGIC_NUMBER_SIZE 1
 #define SCHEMA_ID_LENGTH  32
@@ -45,11 +47,15 @@
 
 //      "schemaTypeUUID" : "3053b4ab-d3f9-4cc9-8c3e-f0bde4a2e6ca",
 //      "schemaMD5Hash" :  "da29287d0199d6279cf934ce884426af",
-
+//      "schemaMD5MLOHash" : "fc82b239cdbc6a7dcecbf0a60b49cdd9",
 uint8_t HASH[16] = {0xda, 0x29, 0x28, 0x7d, 0x01, 0x99, 0xd6, 0x27,
                     0x9c, 0xf9, 0x34, 0xce, 0x88, 0x44, 0x26, 0xaf
                    };
 
+uint8_t MLO_HASH[16] = {0xfc, 0x82, 0xb2, 0x39, 0xcd, 0xbc, 0x6a, 0x7d,
+                    0xce, 0xcb, 0xf0, 0xa6, 0x0b, 0x49, 0xcd, 0xd9
+                   };
+                   
 uint8_t UUID[16] = {0x30, 0x53, 0xb4, 0xab, 0xd3, 0xf9, 0x4c, 0xc9,
                     0x8c, 0x3e, 0xf0, 0xbd, 0xe4, 0xa2, 0xe6, 0xca
                    };
@@ -60,6 +66,7 @@ static char CpemacStr[ 32 ] = {0}; //CID 559876 Buffer not null terminated
 BOOL schema_file_parsed = FALSE;
 char *ndsschemabuffer = NULL;
 char *nds_schemaidbuffer = "3053b4ab-d3f9-4cc9-8c3e-f0bde4a2e6ca/da29287d0199d6279cf934ce884426af";
+char *nds_MLOschemaidbuffer = "3053b4ab-d3f9-4cc9-8c3e-f0bde4a2e6ca/fc82b239cdbc6a7dcecbf0a60b49cdd9";
 static size_t AvroSerializedSize;
 static size_t OneAvroSerializedSize;
 static char AvroSerializedBuf[ WRITER_BUF_SIZE ];
@@ -71,6 +78,8 @@ extern pthread_mutex_t LmHostObjectMutex;
 #ifndef UTC_ENABLE
 extern int getTimeOffsetFromUtc();
 #endif
+
+bool MLORfcEnable = false;
 
 // local data, load it with real data if necessary
 char ReportSource[] = "LMLite";
@@ -96,14 +105,24 @@ return len;
 
 char* GetNDStatusSchemaIDBuffer()
 {
+  if(MLORfcEnable == true)
+    return nds_MLOschemaidbuffer;
+  else
   return nds_schemaidbuffer;
 }
 
 int GetNDStatusSchemaIDBufferSize()
 {
 int len = 0;
+if(MLORfcEnable == true)
+{
+    len = strlen(nds_MLOschemaidbuffer);
+}
+else
+{
 if(nds_schemaidbuffer)
         len = strlen(nds_schemaidbuffer);
+}
 
 return len;
 }
@@ -134,12 +153,34 @@ avro_writer_t prepare_writer_status()
 
   CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, Avro prepares to serialize data\n"));
 
+  static bool previous_isMLORfcEnabled = false;
+  if(MLORfcEnable != previous_isMLORfcEnabled)
+  {
+    CcspTraceInfo(("LMLite %s: MLORfcEnable changed from %s to %s, resetting schema_file_parsed to FALSE\n",
+                           __FUNCTION__,
+                           previous_isMLORfcEnabled ? "true" : "false",
+                           MLORfcEnable ? "true" : "false"));
+    previous_isMLORfcEnabled = MLORfcEnable;
+    nds_avro_cleanup(); // reset to re-parse correct schema file based on MLO RFC feature state
+  }
+
+
   if ( schema_file_parsed == FALSE )
   {
     FILE *fp;
     /* open schema file */
+    if( MLORfcEnable == true )
+    {
+      CcspTraceInfo(("MLO RFC enabled, opening avro file: %s\n",NETWORK_DEVICE_STATUS_MLO_AVRO_FILENAME));
+      fp = fopen ( NETWORK_DEVICE_STATUS_MLO_AVRO_FILENAME , "rb" );
+      if ( !fp ) perror( NETWORK_DEVICE_STATUS_MLO_AVRO_FILENAME " doesn't exist."), exit(1);
+    }
+    else 
+    {
+      CcspTraceInfo(("MLO RFC disabled, opening avro file: %s\n",NETWORK_DEVICE_STATUS_AVRO_FILENAME));
     fp = fopen ( NETWORK_DEVICE_STATUS_AVRO_FILENAME , "rb" );
     if ( !fp ) perror( NETWORK_DEVICE_STATUS_AVRO_FILENAME " doesn't exist."), exit(1);
+    }
 
     /* seek through file and get file size*/
     fseek( fp , 0L , SEEK_END);
@@ -188,7 +229,14 @@ avro_writer_t prepare_writer_status()
 
   memcpy( &AvroSerializedBuf[ MAGIC_NUMBER_SIZE ], UUID, sizeof(UUID));
 
+if(MLORfcEnable == true)
+{
+  memcpy( &AvroSerializedBuf[ MAGIC_NUMBER_SIZE + sizeof(UUID) ], MLO_HASH, sizeof(MLO_HASH));
+}
+else
+{
   memcpy( &AvroSerializedBuf[ MAGIC_NUMBER_SIZE + sizeof(UUID) ], HASH, sizeof(HASH));
+}
 
   writer = avro_writer_memory( (char*)&AvroSerializedBuf[MAGIC_NUMBER_SIZE + SCHEMA_ID_LENGTH],
                                sizeof(AvroSerializedBuf) - MAGIC_NUMBER_SIZE - SCHEMA_ID_LENGTH );
@@ -221,6 +269,8 @@ void network_devices_status_report(struct networkdevicestatusdata *head, BOOL ex
   CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, numElements = %d\n", numElements ));
 
   OneAvroSerializedSize = 0;
+
+  MLORfcEnable = get_lmLiteMLORfcEnable();
 
   /* goes thru total number of elements in link list */
   writer = prepare_writer_status();
@@ -352,6 +402,11 @@ void network_devices_status_report(struct networkdevicestatusdata *head, BOOL ex
     avro_value_set_null(&optional);
     CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, cpe_parent\tType: %d\n", avro_value_get_type(&optional)));
     if ( CHK_AVRO_ERR ) CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, %s\n", avro_strerror()));
+
+    if(MLORfcEnable == true)
+    {
+      // MLO report
+    }
   }
   else
   {

--- a/source/lm/network_devices_status_avropack.c
+++ b/source/lm/network_devices_status_avropack.c
@@ -79,7 +79,7 @@ extern pthread_mutex_t LmHostObjectMutex;
 extern int getTimeOffsetFromUtc();
 #endif
 
-bool MLORfcEnable = false;
+static bool MLORfcEnable = false;
 
 // local data, load it with real data if necessary
 char ReportSource[] = "LMLite";
@@ -171,13 +171,17 @@ avro_writer_t prepare_writer_status()
     /* open schema file */
     if( MLORfcEnable == true )
     {
-      CcspTraceInfo(("MLO RFC enabled, opening avro file: %s\n",NETWORK_DEVICE_STATUS_MLO_AVRO_FILENAME));
+      CcspTraceInfo(("opening avro file: %s\n",NETWORK_DEVICE_STATUS_MLO_AVRO_FILENAME));
       fp = fopen ( NETWORK_DEVICE_STATUS_MLO_AVRO_FILENAME , "rb" );
-      if ( !fp ) perror( NETWORK_DEVICE_STATUS_MLO_AVRO_FILENAME " doesn't exist."), exit(1);
+      if ( !fp )
+      {
+        CcspTraceError(("Failed to open MLO avro schema file %s\n", NETWORK_DEVICE_STATUS_MLO_AVRO_FILENAME));
+        perror( NETWORK_DEVICE_STATUS_MLO_AVRO_FILENAME " doesn't exist."), exit(1);
+      }
     }
     else 
     {
-      CcspTraceInfo(("MLO RFC disabled, opening avro file: %s\n",NETWORK_DEVICE_STATUS_AVRO_FILENAME));
+      CcspTraceInfo(("opening avro file: %s\n",NETWORK_DEVICE_STATUS_AVRO_FILENAME));
     fp = fopen ( NETWORK_DEVICE_STATUS_AVRO_FILENAME , "rb" );
     if ( !fp ) perror( NETWORK_DEVICE_STATUS_AVRO_FILENAME " doesn't exist."), exit(1);
     }
@@ -252,6 +256,7 @@ void network_devices_status_report(struct networkdevicestatusdata *head, BOOL ex
 {
   int i = 0, k = 0;
   int numElements = 0;
+  int MLODevices = 0;
   struct networkdevicestatusdata* ptr = head;
   avro_writer_t writer;
   char * serviceName = "lmlite";
@@ -402,11 +407,6 @@ void network_devices_status_report(struct networkdevicestatusdata *head, BOOL ex
     avro_value_set_null(&optional);
     CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, cpe_parent\tType: %d\n", avro_value_get_type(&optional)));
     if ( CHK_AVRO_ERR ) CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, %s\n", avro_strerror()));
-
-    if(MLORfcEnable == true)
-    {
-      // MLO report
-    }
   }
   else
   {
@@ -631,6 +631,51 @@ void network_devices_status_report(struct networkdevicestatusdata *head, BOOL ex
       CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, \tipaddress\tType: %d\n", avro_value_get_type(&optional)));
       if ( CHK_AVRO_ERR ) CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, %s\n", avro_strerror()));
 
+      if(MLORfcEnable == true)
+      {
+        if(ptr->mlo_used == true)
+          MLODevices++;
+
+        avro_value_get_by_name(&dr, "mlo_used", &drField, NULL);
+        if ( CHK_AVRO_ERR ) CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, %s\n", avro_strerror()));
+        avro_value_set_branch(&drField, 1, &optional);
+        avro_value_set_boolean(&optional, ptr->mlo_used);
+        CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, \tmlo_used:%s\tType: %d\n", ptr->mlo_used ? "true" : "false", avro_value_get_type(&optional)));
+        if ( CHK_AVRO_ERR ) CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, %s\n", avro_strerror()));
+
+        avro_value_get_by_name(&dr, "mlo_bands", &drField, NULL);
+        if ( CHK_AVRO_ERR ) CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, %s\n", avro_strerror()));
+        avro_value_set_branch(&drField, 1, &optional);
+        if( ptr->mlo_bands == NULL )
+        {
+          avro_value_set_null(&optional);
+          CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, \tmlo_bands is NULL, set to null in avro\tType: %d\n", avro_value_get_type(&optional)));
+        }
+        else
+        {
+          avro_value_set_string(&optional, ptr->mlo_bands);
+          CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, \tmlo_bands:%s\tType: %d\n", ptr->mlo_bands, avro_value_get_type(&optional)));
+        }
+        if ( CHK_AVRO_ERR ) CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, %s\n", avro_strerror()));
+
+        avro_value_get_by_name(&dr, "mlo_mode", &drField, NULL);
+        if ( CHK_AVRO_ERR ) CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, %s\n", avro_strerror()));
+        avro_value_set_branch(&drField, 1, &optional);
+        if( ptr->mlo_mode == NULL )
+        {
+          avro_value_set_null(&optional);
+          CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, \tmlo_mode is NULL, set to null in avro\tType: %d\n", avro_value_get_type(&optional)));
+        }
+        else
+        {
+          avro_value_set_string(&optional, ptr->mlo_mode);
+          CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, \tmlo_mode:%s\tType: %d\n", ptr->mlo_mode, avro_value_get_type(&optional)));
+        }
+        if ( CHK_AVRO_ERR ) CcspLMLiteConsoleTrace(("RDK_LOG_DEBUG, %s\n", avro_strerror()));
+
+      }
+
+
       i++;
     }
 
@@ -665,7 +710,8 @@ void network_devices_status_report(struct networkdevicestatusdata *head, BOOL ex
   avro_writer_free(writer);
   //free(buffer);
 
-
+  if(MLORfcEnable == true)
+    CcspTraceInfo(("Number of NON MLO devices = %d, Number of MLO devices = %d, Total number of associated devices data packed for sending = %d \n", numElements-MLODevices, MLODevices, numElements));
 
 /*  if ( consoleDebugEnable )
   {

--- a/source/lm/network_devices_status_avropack.h
+++ b/source/lm/network_devices_status_avropack.h
@@ -24,8 +24,10 @@
 
 #if (defined SIMULATION)
 #define NETWORK_DEVICE_STATUS_AVRO_FILENAME			"NetworkDevicesStatus.avsc"
+#define NETWORK_DEVICE_STATUS_MLO_AVRO_FILENAME			"NetworkDevicesStatusMLO.avsc"
 #else
 #define NETWORK_DEVICE_STATUS_AVRO_FILENAME			"/usr/ccsp/lm/NetworkDevicesStatus.avsc"
+#define NETWORK_DEVICE_STATUS_MLO_AVRO_FILENAME			"/usr/ccsp/lm/NetworkDevicesStatusMLO.avsc"
 #endif
 #define CHK_AVRO_ERR (( NULL != avro_strerror() ) && ( strlen(avro_strerror()) > 0) )
 
@@ -39,6 +41,9 @@ char* parent;
 char* device_type;
 char* hostname;
 char* ipaddress;
+bool mlo_used;
+char* mlo_bands;
+char* mlo_mode;
 struct networkdevicestatusdata *next;
 };
 

--- a/source/lm/network_devices_status_avropack.h
+++ b/source/lm/network_devices_status_avropack.h
@@ -21,6 +21,7 @@
 #define NETWORK_DEVICES_STATUS_AVROPACK_H
 
 #include <sys/time.h>
+#include <stdbool.h>
 
 #if (defined SIMULATION)
 #define NETWORK_DEVICE_STATUS_AVRO_FILENAME			"NetworkDevicesStatus.avsc"

--- a/source/lm/webpa_interface.c
+++ b/source/lm/webpa_interface.c
@@ -32,6 +32,7 @@
 #include "platform_hal.h"
 #ifdef WAN_FAILOVER_SUPPORTED
 #include "network_devices_traffic_avropack.h"
+#include "lm_rbus_api.h"
 #endif
 
 #ifdef MLT_ENABLED
@@ -497,38 +498,11 @@ char * getDeviceMac()
 }
 
 #ifdef WAN_FAILOVER_SUPPORTED
-static bool isRbus = false ;
 char newSource[512] = { '\0' };
 
-//Checking the Rbus active status
-bool checkRbusEnabled()
-{
-        if(RBUS_ENABLED == rbus_checkStatus())
-	{
-		isRbus = true;
-	}
-	else
-	{
-		isRbus = false;
-	}
-	CcspTraceInfo(("LMLite RBUS mode active status = %s\n", isRbus ? "true":"false"));
-	return isRbus;
-}
 
-//Initiate Rbus
-LMLITE_STATUS lmliteRbusInit(const char *pComponentName)
-{
-	int ret = RBUS_ERROR_SUCCESS;
-        CcspTraceDebug(("rbus_open for component %s\n", pComponentName));
-	ret = rbus_open(&rbus_handle, pComponentName);
-	if(ret != RBUS_ERROR_SUCCESS)
-	{
-		CcspTraceError(("LMLiteRbusInit failed with error code %d\n", ret));
-		return LMLITE_FAILURE;
-	}
-	CcspTraceInfo(("LMLiteRbusInit is success. ret is %d\n", ret));
-	return LMLITE_SUCCESS;
-}
+void set_rbus_handle()
+{  rbus_handle = get_rbus_handle(); }
 
 //Filter the active Interfaces
 char* get_ActiveInterface(char *interface) {

--- a/source/lm/webpa_interface.h
+++ b/source/lm/webpa_interface.h
@@ -29,14 +29,7 @@
 #include <stdbool.h>
 #include <rbus/rbus.h>
 
-#define LMLITE_COMPONENT_NAME "lmlite"
 #define LMLITE_INTERFACE_ACTIVESTATUS_PARAM "Device.X_RDK_WanManager.InterfaceActiveStatus"
-
-typedef enum
-{
-    LMLITE_SUCCESS = 0,
-    LMLITE_FAILURE
-} LMLITE_STATUS;
 
 #endif
 /**
@@ -66,12 +59,11 @@ void initparodusTask();
 const char *rdk_logger_module_fetch(void); 
 
 #ifdef WAN_FAILOVER_SUPPORTED
-bool checkRbusEnabled();
-LMLITE_STATUS lmliteRbusInit(const char *pComponentName);
 char* getInterface(char *interface);
 void get_WanManager_ActiveInterface();
 char * get_ActiveInterface(char *interface);
 int subscribeTo_InterfaceActiveStatus_Event();
+void set_rbus_handle();
 #endif
 
 #endif /* WEB_INTERFACE_H_ */

--- a/source/test/Makefile.am
+++ b/source/test/Makefile.am
@@ -53,6 +53,7 @@ CcspLMLite_gtest_bin_SOURCES = gtest_main.cpp \
                                $(top_srcdir)/source/lm/network_devices_status_avropack.c \
                                $(top_srcdir)/source/lm/network_devices_traffic.c \
                                $(top_srcdir)/source/lm/webpa_interface.c \
+                               $(top_srcdir)/source/lm/lm_rbus_api.c \
                                $(top_srcdir)/source/lm/network_devices_traffic_avropack.c \
                                $(top_srcdir)/source/lm/lm_wrapper_priv.c \
                                $(top_srcdir)/source/lm/lm_api_test.c \

--- a/source/test/webpa_interfaceTest.cpp
+++ b/source/test/webpa_interfaceTest.cpp
@@ -28,6 +28,7 @@ extern "C"
 #include "../lm/webpa_interface.h"
 #include "../lm/network_devices_traffic_avropack.h"
 #include <rbus/rbus.h>  
+#include  "../lm/lm_rbus_api.h"
 }
 
 extern rbusMock * g_rbusMock;
@@ -47,12 +48,12 @@ TEST_F(CcspLMLiteTestFixture, checkRbusEnabledFailure) {
 
 TEST_F(CcspLMLiteTestFixture, lmliteRbusInitSuccess) {
     EXPECT_CALL(*g_rbusMock, rbus_open(_, _)).WillOnce(::testing::Return(RBUS_ERROR_SUCCESS));
-    ASSERT_EQ(lmliteRbusInit("_"), LMLITE_SUCCESS);
+    ASSERT_EQ(lmliteRbusInit("_"), RBUS_ERROR_SUCCESS);
 }
 
 TEST_F(CcspLMLiteTestFixture, lmliteRbusInitFailure) {
     EXPECT_CALL(*g_rbusMock, rbus_open(_, _)).WillOnce(::testing::Return(RBUS_ERROR_BUS_ERROR));
-    ASSERT_EQ(lmliteRbusInit("_"), LMLITE_FAILURE);
+    ASSERT_EQ(lmliteRbusInit("_"), RBUS_ERROR_BUS_ERROR);
 }
 
 TEST_F(CcspLMLiteTestFixture, rdk_logger_module_fetchSuccess) {


### PR DESCRIPTION
Reason for change: Enable LMLite support for WiFi MLO reporting in NetworkDeviceStatus report
Test Procedure: US functionality should work
Priority: P1
Risks: Medium
Signed-off-by: LakshmiRangaiah_Narapuram@comcast.com