### PR TITLE
RDKB-65641:Logs are flooding in LM.txt

### DIFF
--- a/source/lm/device_presence_detection.c
+++ b/source/lm/device_presence_detection.c
@@ -721,7 +721,7 @@ void sendProbeRequest (int iIpVersion, char * pIpAddress, char * pIface)
         close(iSocketFd);
         return;
     }
-    CcspTraceInfo(("%s:%d, Probe request sent for IP:%s on interface:%s\n",__FUNCTION__,__LINE__,pIpAddress,pIface));
+    CcspTraceDebug(("%s:%d, Probe request sent for IP:%s on interface:%s\n",__FUNCTION__,__LINE__,pIpAddress,pIface));
     close(iSocketFd);
     return;
 }

--- a/source/lm/lm_wrapper.c
+++ b/source/lm/lm_wrapper.c
@@ -1788,7 +1788,7 @@ int getIPAddress(char *physAddress,char *IPAddress)
         if (output[0] != '\0')
         {
             memcpy(IPAddress,output,sizeof(output));
-            AnscTraceDebug(("client is either reachable or delay: MAC %s IP %s\n", physAddress, IPAddress));
+            CcspTraceDebug(("client is either reachable or delay: MAC %s IP %s\n", physAddress, IPAddress));
             pclose(fp);
             fp = NULL;
             return 0;
@@ -1813,7 +1813,7 @@ int getIPAddress(char *physAddress,char *IPAddress)
         if (output[0] != '\0')
         {
              memcpy(IPAddress,output,sizeof(output));
-             AnscTraceDebug(("client is in stale state: MAC %s IP %s\n", physAddress, IPAddress));
+             CcspTraceDebug(("client is in stale state: MAC %s IP %s\n", physAddress, IPAddress));
              pclose(fp);
              fp = NULL;
              return 0;

--- a/source/lm/lm_wrapper.c
+++ b/source/lm/lm_wrapper.c
@@ -1788,7 +1788,7 @@ int getIPAddress(char *physAddress,char *IPAddress)
         if (output[0] != '\0')
         {
             memcpy(IPAddress,output,sizeof(output));
-            AnscTraceWarning(("client is either reachable or delay: MAC %s IP %s\n", physAddress, IPAddress));
+            AnscTraceDebug(("client is either reachable or delay: MAC %s IP %s\n", physAddress, IPAddress));
             pclose(fp);
             fp = NULL;
             return 0;
@@ -1813,7 +1813,7 @@ int getIPAddress(char *physAddress,char *IPAddress)
         if (output[0] != '\0')
         {
              memcpy(IPAddress,output,sizeof(output));
-             AnscTraceWarning(("client is in stale state: MAC %s IP %s\n", physAddress, IPAddress));
+             AnscTraceDebug(("client is in stale state: MAC %s IP %s\n", physAddress, IPAddress));
              pclose(fp);
              fp = NULL;
              return 0;


### PR DESCRIPTION
rdkb 65641:Logs are flooding in LM.txt
**Reason for code change:** The warning messages are generated when a MAC address is successfully found in the Linux neighbor table with a state of REACHABLE, DELAY, or STALE. In all of these cases the function returns success and treats the client as valid.
The current lab setup contains approximately 52 WiFi test clients(All are virtual clients), so the reachability-monitoring routine generates one log entry per client during each scan cycle. This results in a large volume of warning messages.

Based on the collected evidence:
Neighbor table entries are valid and reachable.
CPU and memory utilization remain normal.
Therefore, this appears to be a logging verbosity/severity issue. Hence we reduce the log level from WARN to DEBUG to avoid excessive log generation in large client environments.
