### PR TITLE
fix: change fallback address source from Static to DHCP in lm_wrapper

### DIFF
--- a/source/lm/lm_wrapper.c
+++ b/source/lm/lm_wrapper.c
@@ -1571,7 +1571,7 @@ memset(buf,0,sizeof(buf));
     fclose(fp);
    if(rc == -1)
    {
-     rc = STRCPY_S_NOCLOBBER(pAddressSource, 20,"Static");
+     rc = STRCPY_S_NOCLOBBER(pAddressSource, 20,"DHCP");
      ERR_CHK(rc);
 
    }


### PR DESCRIPTION
## Summary

In `source/lm/lm_wrapper.c`, the `get_HostInfo()` function uses a fallback block when no static lease match is found (`rc == -1`). Previously this block set `pAddressSource` to `"Static"`, which incorrectly labels dynamically assigned hosts.

## Change

```c
// Before
if(rc == -1)
{
  rc = STRCPY_S_NOCLOBBER(pAddressSource, 20, "Static");
  ERR_CHK(rc);
}

// After
if(rc == -1)
{
  rc = STRCPY_S_NOCLOBBER(pAddressSource, 20, "DHCP");
  ERR_CHK(rc);
}
```

## File Changed
- `source/lm/lm_wrapper.c` — line 1574