### PR TITLE
RDKB-66031: change fallback address source from Static to DHCP in lm_wrapper

### DIFF
--- a/source/lm/lm_wrapper.c
+++ b/source/lm/lm_wrapper.c
@@ -1571,7 +1571,7 @@ memset(buf,0,sizeof(buf));
     fclose(fp);
    if(rc == -1)
    {
-     rc = STRCPY_S_NOCLOBBER(pAddressSource, 20,"Static");
+     rc = STRCPY_S_NOCLOBBER(pAddressSource, 20,"DHCP");
      ERR_CHK(rc);
 
    }


### PR DESCRIPTION
Reason for change: Resolves an issue where MAC address randomization caused the network configuration to switch from DHCP to Static. The address source now remains DHCP unless a custom static IP is set.
Test Procedure:  Trigger a DHCP release from client and check AddressSource 
Risks: Low
Priority: P2

Signed-off-by: Veeraputhiran_Thangavel@comcast.com
