### PR TITLE
XB10-2559: [XB10-Commercial] Client IPv4 Address Displayed in MSO UI Despite LAN DHCP is Disabled

### DIFF
--- a/source/lm/lm_main.c
+++ b/source/lm/lm_main.c
@@ -352,7 +352,7 @@ static void Host_FreeIPAddress(PLmObjectHost pHost, int version);
 static void Host_FreeMloLinks (PLmObjectHost pHost);
 static void Hosts_SyncDHCP(void);
 static BOOL LanMgr_IsLanDhcpv4Enabled(void);
-static void Clean_Expired_DHCP_Hosts_OnDhcpDisabled(void);
+static void Hosts_CleanExpiredDHCP(void);
 static void Sendmsg_dnsmasq(BOOL enablePresenceFeature);
 static void Send_Eth_Host_Sync_Req(void);
 
@@ -1109,10 +1109,10 @@ static BOOL LanMgr_IsLanDhcpv4Enabled(void)
     return (strcmp(value, "0") != 0);
 }
 
-/* Requirement: once LAN DHCP is disabled, expired DHCP leases must be removed from the host table (not just hidden in UI) */
-static void Clean_Expired_DHCP_Hosts_OnDhcpDisabled(void)
+/* Requirement: once LAN DHCP is disabled, expired DHCP lease's IPv4 address must be cleared from the host entry (host entry itself is kept) */
+static void Hosts_CleanExpiredDHCP(void)
 {
-    int count, count1, total_count;
+    int count, total_count;
     time_t currentTime;
 
     if (LanMgr_IsLanDhcpv4Enabled())
@@ -1131,25 +1131,14 @@ static void Clean_Expired_DHCP_Hosts_OnDhcpDisabled(void)
 
         if(pHost &&
             (strcmp(pHost->pStringParaValue[LM_HOST_AddressSource], LM_ADDRESS_SOURCE_DHCP_STR) == 0) &&
-            (pHost->LeaseTime != 0xFFFFFFFF) && (currentTime >= (time_t)pHost->LeaseTime))
+            (pHost->LeaseTime != 0xFFFFFFFF) && (currentTime >= (time_t)pHost->LeaseTime) &&
+            (pHost->numIPv4Addr > 0))
         {
-            CcspTraceWarning(("LAN DHCP disabled: removing expired host %s\n",pHost->pStringParaValue[LM_HOST_PhysAddressId]));
-            Hosts_FreeHost(pHost);
-            lmHosts.hostArray[count] = NULL;
+            CcspTraceWarning(("LAN DHCP disabled: clearing expired IPv4 for host %s\n",pHost->pStringParaValue[LM_HOST_PhysAddressId]));
+            Host_FreeIPAddress(pHost, 4);
+            pHost->ipv4Active = FALSE;
+            LanManager_CheckCloneCopy(&(pHost->pStringParaValue[LM_HOST_IPAddressId]), "");
         }
-    }
-
-    for(count=0 ; count < total_count; count++)
-    {
-        if(lmHosts.hostArray[count]) continue;
-        for(count1=count+1; count1 < total_count; count1++)
-        {
-            if(lmHosts.hostArray[count1]) break;
-        }
-        if(count1 >= total_count) break;
-        lmHosts.hostArray[count] = lmHosts.hostArray[count1];
-        lmHosts.hostArray[count]->instanceNum = count+1;
-        lmHosts.hostArray[count1] = NULL;
     }
 
     pthread_mutex_unlock(&LmHostObjectMutex);
@@ -3031,7 +3020,7 @@ static void *Hosts_StatSyncThreadFunc(void *args)
             Hosts_SyncDHCP();
             Hosts_SyncArp();
             Add_IPv6_from_Dibbler();
-            Clean_Expired_DHCP_Hosts_OnDhcpDisabled();
+            Hosts_CleanExpiredDHCP();
         }
     }
     return NULL;

--- a/source/lm/lm_main.c
+++ b/source/lm/lm_main.c
@@ -351,6 +351,8 @@ static void Wifi_ServerSyncHost(char *phyAddr, char apList[][LM_GEN_STR_SIZE], c
 static void Host_FreeIPAddress(PLmObjectHost pHost, int version);
 static void Host_FreeMloLinks (PLmObjectHost pHost);
 static void Hosts_SyncDHCP(void);
+static BOOL LanMgr_IsLanDhcpv4Enabled(void);
+static void Clean_Expired_DHCP_Hosts_OnDhcpDisabled(void);
 static void Sendmsg_dnsmasq(BOOL enablePresenceFeature);
 static void Send_Eth_Host_Sync_Req(void);
 
@@ -1094,6 +1096,64 @@ static void Clean_Host_Table (void)
         lmHosts.hostArray[count]->instanceNum = count+1;
         lmHosts.hostArray[count1] = NULL;
     }
+}
+
+/* syscfg key toggled by Device.DHCPv4.Server.Enable; LAN DHCP off means this reads "0" */
+static BOOL LanMgr_IsLanDhcpv4Enabled(void)
+{
+    char value[16] = {0};
+
+    if (syscfg_get(NULL, "dhcp_server_enabled", value, sizeof(value)) != 0)
+        return TRUE;
+
+    return (strcmp(value, "0") != 0);
+}
+
+/* Requirement: once LAN DHCP is disabled, expired DHCP leases must be removed from the host table (not just hidden in UI) */
+static void Clean_Expired_DHCP_Hosts_OnDhcpDisabled(void)
+{
+    int count, count1, total_count;
+    time_t currentTime;
+
+    if (LanMgr_IsLanDhcpv4Enabled())
+        return;
+
+    CcspTraceDebug(("%s:%d, Acquiring LmHostObjectMutex\n",__FUNCTION__,__LINE__));
+    pthread_mutex_lock(&LmHostObjectMutex);
+    CcspTraceDebug(("%s:%d, Acquired LmHostObjectMutex\n",__FUNCTION__,__LINE__));
+
+    currentTime = time(NULL);
+    total_count = lmHosts.numHost;
+
+    for(count=0 ; count < total_count; count++)
+    {
+        PLmObjectHost pHost = lmHosts.hostArray[count];
+
+        if(pHost &&
+            (strcmp(pHost->pStringParaValue[LM_HOST_AddressSource], LM_ADDRESS_SOURCE_DHCP_STR) == 0) &&
+            (pHost->LeaseTime != 0xFFFFFFFF) && (currentTime >= (time_t)pHost->LeaseTime))
+        {
+            CcspTraceWarning(("LAN DHCP disabled: removing expired host %s\n",pHost->pStringParaValue[LM_HOST_PhysAddressId]));
+            Hosts_FreeHost(pHost);
+            lmHosts.hostArray[count] = NULL;
+        }
+    }
+
+    for(count=0 ; count < total_count; count++)
+    {
+        if(lmHosts.hostArray[count]) continue;
+        for(count1=count+1; count1 < total_count; count1++)
+        {
+            if(lmHosts.hostArray[count1]) break;
+        }
+        if(count1 >= total_count) break;
+        lmHosts.hostArray[count] = lmHosts.hostArray[count1];
+        lmHosts.hostArray[count]->instanceNum = count+1;
+        lmHosts.hostArray[count1] = NULL;
+    }
+
+    pthread_mutex_unlock(&LmHostObjectMutex);
+    CcspTraceDebug(("%s:%d, unlocked LmHostObjectMutex\n",__FUNCTION__,__LINE__));
 }
 
 static PLmObjectHost Hosts_AddHost (int instanceNum)
@@ -2971,6 +3031,7 @@ static void *Hosts_StatSyncThreadFunc(void *args)
             Hosts_SyncDHCP();
             Hosts_SyncArp();
             Add_IPv6_from_Dibbler();
+            Clean_Expired_DHCP_Hosts_OnDhcpDisabled();
         }
     }
     return NULL;

--- a/source/lm/network_devices_status.c
+++ b/source/lm/network_devices_status.c
@@ -40,6 +40,7 @@
 #include "safec_lib_common.h"
 #include "secure_wrapper.h"
 #include "lm_rbus_api.h"
+#include "syscfg/syscfg.h"
 
 static pthread_mutex_t ndsMutex = PTHREAD_MUTEX_INITIALIZER;
 static pthread_cond_t ndsCond = PTHREAD_COND_INITIALIZER;
@@ -76,6 +77,43 @@ static struct networkdevicestatusdata *headnode = NULL;
 static struct networkdevicestatusdata *headnodeextender = NULL;
 
 extern pthread_mutex_t LmHostObjectMutex;
+
+static BOOL NDS_GetSyscfgBool(const char *key, BOOL defaultValue)
+{
+    char value[16] = {0};
+
+    if (key == NULL)
+    {
+        return defaultValue;
+    }
+
+    if (syscfg_get(NULL, key, value, sizeof(value)) != 0)
+    {
+        return defaultValue;
+    }
+
+    if ((strcasecmp(value, "true") == 0) || (strcmp(value, "1") == 0))
+    {
+        return TRUE;
+    }
+
+    if ((strcasecmp(value, "false") == 0) || (strcmp(value, "0") == 0))
+    {
+        return FALSE;
+    }
+
+    return defaultValue;
+}
+
+static BOOL NDS_IsDhcpAddressSource(PLmObjectHost host)
+{
+    if ((host == NULL) || (host->pStringParaValue[LM_HOST_AddressSource] == NULL))
+    {
+        return FALSE;
+    }
+
+    return (strstr(host->pStringParaValue[LM_HOST_AddressSource], "DHCP") != NULL);
+}
 
 // RDKB-9258 : set polling and reporting periods to NVRAM after TTL expiry
 extern ANSC_STATUS SetNDSPollingPeriodInNVRAM(ULONG pPollingVal);
@@ -519,14 +557,23 @@ char* NDS_GetIpAddress(PLmObjectHost host)
     char *pIpv4address = NULL;
     char *pIpv6addressindex1 = NULL;
     char *pIpv6addressindex3 = NULL;
+    BOOL dhcpv4Enabled = NDS_GetSyscfgBool("dhcp_server_enabled", TRUE);
+    BOOL dhcpSource = FALSE;
 
     if (!host)
         return strdup("Unknown");
+
+    dhcpSource = NDS_IsDhcpAddressSource(host);
 
     // By default PLmObjectHost pStringParaValue ipaddress holds ipv4 address.
     if(host->pStringParaValue[LM_HOST_IPAddressId])
     {
         pIpv4address = host->pStringParaValue[LM_HOST_IPAddressId];
+    }
+
+    if ((!dhcpv4Enabled) && dhcpSource)
+    {
+        pIpv4address = NULL;
     }
 
     if ((!host->ipv6Active) && (!pIpv4address))


### PR DESCRIPTION

Reason for change: When LAN DHCP is disabled and if lease expires, ipv4 address are removed from host table. 
Test Procedure: 
1. Disable LAN DHCP
2. Wait for lease time to expire
3. Check host table entry
Risks: Low 
Priority: P1

Unit testing Logs attached:
[XB10-2559-LOGS.docx](https://github.com/user-attachments/files/31260543/XB10-2559-LOGS.docx)
